### PR TITLE
BoothDetailSheet, ShowDetailSheet 퍼블리싱 & api 연결

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,7 +28,9 @@ import MyPage from '@/pages/my/MyPage';
 // 지도
 import MapPage from '@/pages/map/MapPage';
 import BoothListSheet from '@/features/booth/BoothListSheet';
+import BoothDetailSheet from '@/features/booth/BoothDetailSheet';
 import ShowListSheet from '@/features/show/ShowListSheet';
+import ShowDetailSheet from '@/features/show/ShowDetailSheet';
 import EtcSheet from '@/features/EtcSheet';
 import BarrierFreeSheet from '@/features/BarrierFreeSheet';
 
@@ -64,9 +66,9 @@ function App() {
           {/* 지도 */}
           <Route path="map" element={<MapPage />}>
             <Route path="booths" element={<BoothListSheet />} />
-            <Route path="booths/:id" element={<div>BoothDetailSheet</div>} />
+            <Route path="booths/:id" element={<BoothDetailSheet />} />
             <Route path="shows" element={<ShowListSheet />} />
-            <Route path="shows/:id" element={<div>ShowDetailSheet</div>} />
+            <Route path="shows/:id" element={<ShowDetailSheet />} />
             <Route path="etc" element={<EtcSheet />} />
             <Route path="barrierfree" element={<BarrierFreeSheet />} />
           </Route>

--- a/src/features/booth/BoothDetailSheet.jsx
+++ b/src/features/booth/BoothDetailSheet.jsx
@@ -12,6 +12,7 @@ import { BOOTH_CATEGORY } from '@/constants/category';
 import { BOOTH_LOCATION } from '@/constants/building';
 import { getLabel, padNumber } from '@/utils/labelHelper';
 import { formatScheduleDate } from '@/utils/dateHelper';
+import { mapSnsUrls } from '@/utils/snsHelper';
 
 import BottomsheetDrag from '@/components/BottomsheetDrag';
 import Header from '@/components/Header';
@@ -76,10 +77,7 @@ const BoothDetailSheet = () => {
   const locationName = booth.location
     ? `${getLabel(booth.location.building, BOOTH_LOCATION)} ${padNumber(booth.location.number)}`
     : '';
-  const snsLinks = {
-    instagram: booth.sns?.find((url) => url.includes('instagram')),
-    kakaotalk: booth.sns?.find((url) => url.includes('kakao')),
-  };
+  const snsLinks = mapSnsUrls(booth.sns);
 
   return (
     <>

--- a/src/features/booth/BoothDetailSheet.jsx
+++ b/src/features/booth/BoothDetailSheet.jsx
@@ -1,3 +1,292 @@
 /**
  * 부스 상세 바텀시트
  */
+
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import useAlertStore from '@/store/useAlertStore';
+import useBottomsheetStore from '@/store/useBottomsheetStore';
+
+import { BoothAPI } from '@/apis';
+import { BOOTH_CATEGORY } from '@/constants/category';
+import { BOOTH_LOCATION } from '@/constants/building';
+import { getLabel, padNumber } from '@/utils/labelHelper';
+import { formatScheduleDate } from '@/utils/dateHelper';
+
+import BottomsheetDrag from '@/components/BottomsheetDrag';
+import Header from '@/components/Header';
+import ScrapButton from '@/components/ScrapButton';
+import Badge from '@/components/Badge';
+import ImageModal from '@/components/ImageModal';
+import Divider from '@/components/Divider';
+import NoticeCard from '@/components/Card/NoticeCard';
+import Tab from '@/components/Tab';
+import MenuCard from '@/components/Card/MenuCard';
+
+const BoothDetailSheet = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const openAlert = useAlertStore((s) => s.openAlert);
+  const closeAlert = useAlertStore((s) => s.closeAlert);
+  const isFull = useBottomsheetStore((s) => s.isFull());
+
+  const [booth, setBooth] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+  const [activeTab, setActiveTab] = useState(0);
+  const [selectedImage, setSelectedImage] = useState(null);
+
+  useEffect(() => {
+    const fetchBoothDetail = async () => {
+      try {
+        const data = await BoothAPI.getBoothById(id);
+        setBooth(data);
+      } catch (error) {
+        console.error('부스 정보를 불러오는데 실패했습니다:', error);
+        openAlert({
+          variant: 'error',
+          title: '오류',
+          text: '부스 정보를 불러올 수 없습니다.',
+          onConfirm: () => {
+            closeAlert();
+            navigate(-1);
+          },
+        });
+      }
+    };
+
+    if (id) {
+      fetchBoothDetail();
+    }
+  }, [id]);
+
+  if (!booth) {
+    return null;
+  }
+
+  const goNoticePage = () => {
+    navigate(`/admin/booth/${id}/notice`);
+  };
+
+  const categoryText = booth.category?.map((cat) => getLabel(cat, BOOTH_CATEGORY)).join(', ') || '';
+  const scheduleText =
+    booth.schedule?.map((s) => {
+      const formattedDate = formatScheduleDate(s.date);
+      return `${formattedDate} ${s.time}`;
+    }) || [];
+  const locationName = booth.location
+    ? `${getLabel(booth.location.building, BOOTH_LOCATION)} ${padNumber(booth.location.number)}`
+    : '';
+  const snsLinks = {
+    instagram: booth.sns?.find((url) => url.includes('instagram')),
+    kakaotalk: booth.sns?.find((url) => url.includes('kakao')),
+  };
+
+  return (
+    <>
+      <div className={isFull ? 'relative z-10' : 'relative z-20'}>
+        <Header left="back" background="transparent" />
+      </div>
+      <BottomsheetDrag>
+        {isFull && (
+          <>
+            <Header left="back" isSheet />
+            <img
+              src={booth.thumbnail || '/images/default-image-large.png'}
+              className="flex aspect-49/30 w-full items-center justify-center object-cover"
+              onClick={() => {
+                if (booth.thumbnail) {
+                  setSelectedImage(booth.thumbnail);
+                  setShowModal(true);
+                }
+              }}
+            />
+          </>
+        )}
+
+        <div className="flex w-full flex-col items-center gap-9 pt-5">
+          {/* 부스 설명 */}
+          <div className="flex w-full flex-col gap-6 self-stretch px-5">
+            <div className="flex w-full flex-col items-start gap-2 self-stretch">
+              <div className="flex w-full items-center justify-between self-stretch">
+                <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
+                  {booth.name || '부스명'}
+                </h2>
+                <ScrapButton count={booth.scraps_count} />
+              </div>
+
+              {(categoryText || booth.is_ongoing !== undefined) && (
+                <div className="flex items-center gap-1">
+                  {categoryText && (
+                    <p className="text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                      {categoryText}
+                    </p>
+                  )}
+
+                  {booth.is_ongoing !== undefined && (
+                    <>
+                      {categoryText && <img src="/icons/icon-eclipse-gray.svg" />}
+                      <Badge state={booth.is_ongoing ? 'operating' : 'closed'} size="md" />
+                    </>
+                  )}
+                </div>
+              )}
+
+              {booth.description && (
+                <p className="line-clamp-2 max-h-10 self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                  {booth.description}
+                </p>
+              )}
+            </div>
+
+            <Divider />
+
+            <div className="flex-start flex flex-col gap-4 self-stretch">
+              {/* 시간 */}
+              <div className="flex items-start gap-4">
+                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                  시간
+                </h3>
+                <div className="flex flex-col items-start gap-0.5">
+                  {scheduleText.length > 0 ? (
+                    scheduleText.map((t, i) => (
+                      <h3
+                        key={i}
+                        className="text-sm leading-5 font-normal tracking-normal text-zinc-800"
+                      >
+                        {t}
+                      </h3>
+                    ))
+                  ) : (
+                    <h3 className="text-sm leading-5 font-normal tracking-normal text-zinc-800">
+                      -
+                    </h3>
+                  )}
+                </div>
+              </div>
+
+              {/* 위치 */}
+              <div className="flex items-start gap-4">
+                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                  위치
+                </h3>
+                <div className="flex flex-col items-start gap-1.5">
+                  <div className="flex items-center gap-1.5">
+                    <button
+                      className={`text-sm leading-5 font-medium tracking-normal text-zinc-800 ${
+                        locationName
+                          ? 'underline decoration-solid underline-offset-2'
+                          : 'cursor-default'
+                      }`}
+                    >
+                      {locationName || '-'}
+                    </button>
+
+                    {booth.roadview && (
+                      <>
+                        <img src="/icons/icon-eclipse-gray.svg" />
+                        <button
+                          className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
+                          onClick={() => {
+                            setSelectedImage(booth.roadview);
+                            setShowModal(true);
+                          }}
+                        >
+                          로드뷰
+                        </button>
+                      </>
+                    )}
+                  </div>
+
+                  {booth.location_description && (
+                    <p className="text-xs leading-4 font-normal tracking-normal text-zinc-500">
+                      {booth.location_description}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* SNS */}
+              <div className="flex items-start gap-4">
+                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                  SNS
+                </h3>
+                <div className="flex items-center gap-2.5">
+                  {snsLinks.instagram && (
+                    <img
+                      src="/icons/logo-instagramcolor.svg"
+                      className="h-7 w-7 cursor-pointer rounded-md"
+                      onClick={() => window.open(snsLinks.instagram, '_blank')}
+                    />
+                  )}
+
+                  {snsLinks.kakaotalk && (
+                    <img
+                      src="/icons/logo-kakaotalkcolor.svg"
+                      className="h-7 w-7 cursor-pointer rounded-md"
+                      onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
+                    />
+                  )}
+
+                  {!snsLinks.instagram && !snsLinks.kakaotalk && (
+                    <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 공지 */}
+          <div className="w-full px-5">
+            {booth.latest_notice ? (
+              <NoticeCard
+                title={booth.latest_notice.title}
+                onClick={goNoticePage}
+                style={{ cursor: 'pointer' }}
+              />
+            ) : (
+              <NoticeCard title="등록된 공지가 없어요." />
+            )}
+          </div>
+
+          {/* 리스트 */}
+          <div className="flex w-full flex-col items-center gap-2 self-stretch px-5">
+            <Tab
+              variant="underline"
+              tabs={['리스트']}
+              activeIndex={activeTab}
+              onChange={(index) => setActiveTab(index)}
+            />
+            <div className="flex w-full flex-col items-center self-stretch">
+              {activeTab === 0 && (
+                <div className="pb-36">
+                  {booth.product && booth.product.length > 0 ? (
+                    booth.product.map((item) => (
+                      <MenuCard
+                        key={item.id}
+                        name={item.name}
+                        description={item.description}
+                        image={item.image}
+                        price={item.price}
+                        onImageClick={(img) => {
+                          setSelectedImage(img);
+                          setShowModal(true);
+                        }}
+                      />
+                    ))
+                  ) : (
+                    <div className="flex w-full items-center justify-center self-stretch py-20 text-center text-base leading-6 font-normal tracking-normal text-zinc-300">
+                      등록된 내용이 없어요.
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+        {showModal && <ImageModal image={selectedImage} onClose={() => setShowModal(false)} />}
+      </BottomsheetDrag>
+    </>
+  );
+};
+
+export default BoothDetailSheet;

--- a/src/features/show/ShowDetailSheet.jsx
+++ b/src/features/show/ShowDetailSheet.jsx
@@ -12,6 +12,7 @@ import { SHOW_CATEGORY } from '@/constants/category';
 import { SHOW_LOCATION } from '@/constants/building';
 import { getLabel, padNumber } from '@/utils/labelHelper';
 import { formatScheduleDate } from '@/utils/dateHelper';
+import { mapSnsUrls } from '@/utils/snsHelper';
 
 import BottomsheetDrag from '@/components/BottomsheetDrag';
 import Header from '@/components/Header';
@@ -82,10 +83,7 @@ const ShowDetailSheet = () => {
   const locationName = show.location
     ? `${getLabel(show.location.building, SHOW_LOCATION)} ${padNumber(show.location.number)}`
     : '';
-  const snsLinks = {
-    instagram: show.sns?.find((url) => url.includes('instagram')),
-    kakaotalk: show.sns?.find((url) => url.includes('kakao')),
-  };
+  const snsLinks = mapSnsUrls(show.sns);
 
   return (
     <>

--- a/src/features/show/ShowDetailSheet.jsx
+++ b/src/features/show/ShowDetailSheet.jsx
@@ -1,3 +1,287 @@
 /**
  * 공연 상세 바텀시트
  */
+
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import useAlertStore from '@/store/useAlertStore';
+import useBottomsheetStore from '@/store/useBottomsheetStore';
+
+import { ShowAPI } from '@/apis';
+import { SHOW_CATEGORY } from '@/constants/category';
+import { SHOW_LOCATION } from '@/constants/building';
+import { getLabel, padNumber } from '@/utils/labelHelper';
+import { formatScheduleDate } from '@/utils/dateHelper';
+
+import BottomsheetDrag from '@/components/BottomsheetDrag';
+import Header from '@/components/Header';
+import ScrapButton from '@/components/ScrapButton';
+import Badge from '@/components/Badge';
+import ImageModal from '@/components/ImageModal';
+import Divider from '@/components/Divider';
+import NoticeCard from '@/components/Card/NoticeCard';
+import Tab from '@/components/Tab';
+import SetlistCard from '@/components/Card/SetlistCard';
+
+const ShowDetailSheet = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const openAlert = useAlertStore((s) => s.openAlert);
+  const closeAlert = useAlertStore((s) => s.closeAlert);
+  const isFull = useBottomsheetStore((s) => s.isFull());
+
+  const [show, setShow] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+  const [activeTab, setActiveTab] = useState(0);
+  const [selectedImage, setSelectedImage] = useState(null);
+
+  useEffect(() => {
+    const fetchShowDetail = async () => {
+      try {
+        const data = await ShowAPI.getShowById(id);
+        setShow(data);
+      } catch (error) {
+        console.error('공연 정보를 불러오는데 실패했습니다:', error);
+        openAlert({
+          variant: 'error',
+          title: '오류',
+          text: '공연 정보를 불러올 수 없습니다.',
+          onConfirm: () => {
+            closeAlert();
+            navigate(-1);
+          },
+        });
+      }
+    };
+
+    if (id) {
+      fetchShowDetail();
+    }
+  }, [id]);
+
+  if (!show) {
+    return null;
+  }
+
+  const goNoticePage = () => {
+    navigate(`/admin/show/${id}/notice`);
+  };
+
+  const getShowState = (isOngoing) => {
+    if (isOngoing === null) return 'upcoming'; // 공연 전
+    if (isOngoing === true) return 'performing'; // 공연 중
+    return 'closed'; // 공연 종료
+  };
+
+  const categoryText = show.category ? getLabel(show.category, SHOW_CATEGORY) : '';
+  const scheduleText =
+    show.schedule?.map((s) => {
+      const formattedDate = formatScheduleDate(s.date);
+      return `${formattedDate} ${s.time}`;
+    }) || [];
+  const locationName = show.location
+    ? `${getLabel(show.location.building, SHOW_LOCATION)} ${padNumber(show.location.number)}`
+    : '';
+  const snsLinks = {
+    instagram: show.sns?.find((url) => url.includes('instagram')),
+    kakaotalk: show.sns?.find((url) => url.includes('kakao')),
+  };
+
+  return (
+    <>
+      <div className={isFull ? 'relative z-10' : 'relative z-20'}>
+        <Header left="back" background="transparent" />
+      </div>
+      <BottomsheetDrag>
+        {isFull && (
+          <>
+            <Header left="back" isSheet />
+            <img
+              src={show.thumbnail || '/images/default-image-large.png'}
+              className="flex aspect-49/30 w-full items-center justify-center object-cover"
+              onClick={() => {
+                if (show.thumbnail) {
+                  setSelectedImage(show.thumbnail);
+                  setShowModal(true);
+                }
+              }}
+            />
+          </>
+        )}
+
+        <div className="flex w-full flex-col items-center gap-9 pt-5">
+          {/* 부스 설명 */}
+          <div className="flex w-full flex-col gap-6 self-stretch px-5">
+            <div className="flex w-full flex-col items-start gap-2 self-stretch">
+              <div className="flex w-full items-center justify-between self-stretch">
+                <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
+                  {show.name || '공연명'}
+                </h2>
+                <ScrapButton count={show.scraps_count} />
+              </div>
+
+              {(categoryText || show.is_ongoing !== undefined) && (
+                <div className="flex items-center gap-1">
+                  {categoryText && (
+                    <p className="text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                      {categoryText}
+                    </p>
+                  )}
+
+                  {show.is_ongoing !== undefined && (
+                    <>
+                      {categoryText && <img src="/icons/icon-eclipse-gray.svg" />}
+                      <Badge state={getShowState(show.is_ongoing)} size="md" />
+                    </>
+                  )}
+                </div>
+              )}
+
+              {show.description && (
+                <p className="line-clamp-2 max-h-10 self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                  {show.description}
+                </p>
+              )}
+            </div>
+
+            <Divider />
+
+            <div className="flex-start flex flex-col gap-4 self-stretch">
+              {/* 시간 */}
+              <div className="flex items-start gap-4">
+                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                  시간
+                </h3>
+                <div className="flex flex-col items-start gap-0.5">
+                  {scheduleText.length > 0 ? (
+                    scheduleText.map((t, i) => (
+                      <h3
+                        key={i}
+                        className="text-sm leading-5 font-normal tracking-normal text-zinc-800"
+                      >
+                        {t}
+                      </h3>
+                    ))
+                  ) : (
+                    <h3 className="text-sm leading-5 font-normal tracking-normal text-zinc-800">
+                      -
+                    </h3>
+                  )}
+                </div>
+              </div>
+
+              {/* 위치 */}
+              <div className="flex items-start gap-4">
+                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                  위치
+                </h3>
+                <div className="flex flex-col items-start gap-1.5">
+                  <div className="flex items-center gap-1.5">
+                    <button
+                      className={`text-sm leading-5 font-medium tracking-normal text-zinc-800 ${
+                        locationName
+                          ? 'underline decoration-solid underline-offset-2'
+                          : 'cursor-default'
+                      }`}
+                    >
+                      {locationName || '-'}
+                    </button>
+
+                    {show.roadview && (
+                      <>
+                        <img src="/icons/icon-eclipse-gray.svg" />
+                        <button
+                          className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
+                          onClick={() => {
+                            setSelectedImage(show.roadview);
+                            setShowModal(true);
+                          }}
+                        >
+                          로드뷰
+                        </button>
+                      </>
+                    )}
+                  </div>
+
+                  {show.location_description && (
+                    <p className="text-xs leading-4 font-normal tracking-normal text-zinc-500">
+                      {show.location_description}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* SNS */}
+              <div className="flex items-start gap-4">
+                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                  SNS
+                </h3>
+                <div className="flex items-center gap-2.5">
+                  {snsLinks.instagram && (
+                    <img
+                      src="/icons/logo-instagramcolor.svg"
+                      className="h-7 w-7 cursor-pointer rounded-md"
+                      onClick={() => window.open(snsLinks.instagram, '_blank')}
+                    />
+                  )}
+
+                  {snsLinks.kakaotalk && (
+                    <img
+                      src="/icons/logo-kakaotalkcolor.svg"
+                      className="h-7 w-7 cursor-pointer rounded-md"
+                      onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
+                    />
+                  )}
+
+                  {!snsLinks.instagram && !snsLinks.kakaotalk && (
+                    <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 공지 */}
+          <div className="w-full px-5">
+            {show.latest_notice ? (
+              <NoticeCard
+                title={show.latest_notice.title}
+                onClick={goNoticePage}
+                style={{ cursor: 'pointer' }}
+              />
+            ) : (
+              <NoticeCard title="등록된 공지가 없어요." />
+            )}
+          </div>
+
+          {/* 리스트 */}
+          <div className="flex w-full flex-col items-center gap-2 self-stretch px-5">
+            <Tab
+              variant="underline"
+              tabs={['세트리스트']}
+              activeIndex={activeTab}
+              onChange={(index) => setActiveTab(index)}
+            />
+            <div className="flex w-full flex-col items-start self-stretch">
+              {activeTab === 0 && (
+                <div className="flex w-full flex-col gap-2 pb-36">
+                  {show.setlist && show.setlist.length > 0 ? (
+                    show.setlist.map((item) => <SetlistCard key={item.id} title={item.name} />)
+                  ) : (
+                    <div className="flex w-full items-center justify-center self-stretch py-20 text-center text-base leading-6 font-normal tracking-normal text-zinc-300">
+                      등록된 내용이 없어요.
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {showModal && <ImageModal image={selectedImage} onClose={() => setShowModal(false)} />}
+      </BottomsheetDrag>
+    </>
+  );
+};
+
+export default ShowDetailSheet;

--- a/src/pages/NoticePage.jsx
+++ b/src/pages/NoticePage.jsx
@@ -20,6 +20,7 @@ const NoticePage = () => {
   const closeAlert = useAlertStore((s) => s.closeAlert);
   const showLoading = useLoadingStore((s) => s.showLoading);
   const hideLoading = useLoadingStore((s) => s.hideLoading);
+  const isLoading = useLoadingStore((s) => s.isLoading);
 
   // ID로 부스/공연 구분
   const isBooth = id?.startsWith('BOOTH_');
@@ -65,21 +66,21 @@ const NoticePage = () => {
     <>
       <Header left="back" center="title" centerTitle="공지" />
       <div className="mt-18 flex flex-col gap-4 p-5">
-        {notices.length > 0 ? (
-          notices.map((notice) => (
-            <Accordion
-              key={notice.id}
-              title={notice.title}
-              time={notice.time_ago}
-              isUpdate={notice.is_updated}
-              content={notice.content}
-            />
-          ))
-        ) : (
-          <div className="flex justify-center pt-36 text-center text-base font-normal text-zinc-300">
-            등록된 공지가 없어요.
-          </div>
-        )}
+        {notices.length > 0
+          ? notices.map((notice) => (
+              <Accordion
+                key={notice.id}
+                title={notice.title}
+                time={notice.time_ago}
+                isUpdate={notice.is_updated}
+                content={notice.content}
+              />
+            ))
+          : !isLoading && (
+              <div className="flex justify-center pt-36 text-center text-base font-normal text-zinc-300">
+                등록된 공지가 없어요.
+              </div>
+            )}
       </div>
     </>
   );

--- a/src/pages/NoticePage.jsx
+++ b/src/pages/NoticePage.jsx
@@ -27,6 +27,10 @@ const NoticePage = () => {
   const isShow = id?.startsWith('SHOW_');
 
   useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  useEffect(() => {
     const fetchNotices = async () => {
       try {
         showLoading();

--- a/src/pages/admin/MyBoothPage.jsx
+++ b/src/pages/admin/MyBoothPage.jsx
@@ -12,6 +12,7 @@ import { BOOTH_CATEGORY } from '@/constants/category';
 import { BOOTH_LOCATION } from '@/constants/building';
 import { getLabel, padNumber } from '@/utils/labelHelper';
 import { formatScheduleDate } from '@/utils/dateHelper';
+import { mapSnsUrls } from '@/utils/snsHelper';
 
 import Header from '@/components/Header';
 import ScrapButton from '@/components/ScrapButton';
@@ -79,10 +80,7 @@ const MyBoothPage = () => {
   const locationName = booth.location
     ? `${getLabel(booth.location.building, BOOTH_LOCATION)} ${padNumber(booth.location.number)}`
     : '';
-  const snsLinks = {
-    instagram: booth.sns?.find((url) => url.includes('instagram')),
-    kakaotalk: booth.sns?.find((url) => url.includes('kakao')),
-  };
+  const snsLinks = mapSnsUrls(booth.sns);
 
   return (
     <>

--- a/src/pages/admin/MyBoothPage.jsx
+++ b/src/pages/admin/MyBoothPage.jsx
@@ -85,8 +85,8 @@ const MyBoothPage = () => {
   };
 
   return (
-    <div className="relative">
-      <Header className="absolute top-0" left="back" right="edit" background="white" />
+    <>
+      <Header left="back" right="edit" background="white" />
       <img
         src={booth.thumbnail || '/images/default-image-large.png'}
         className="mt-18 flex aspect-49/30 w-full items-center justify-center object-cover"
@@ -169,13 +169,6 @@ const MyBoothPage = () => {
                       locationName ? 'underline decoration-solid underline-offset-2' : ''
                     }`}
                   >
-                    {/* <button
-                    className={`text-sm leading-5 font-medium tracking-normal text-zinc-800 ${
-                      locationName
-                        ? 'underline decoration-solid underline-offset-2'
-                        : 'cursor-default'
-                    }`}
-                  > */}
                     {locationName || '-'}
                   </button>
 
@@ -282,7 +275,7 @@ const MyBoothPage = () => {
         </div>
       </div>
       {showModal && <ImageModal image={selectedImage} onClose={() => setShowModal(false)} />}
-    </div>
+    </>
   );
 };
 

--- a/src/pages/admin/MyShowPage.jsx
+++ b/src/pages/admin/MyShowPage.jsx
@@ -12,6 +12,7 @@ import { SHOW_CATEGORY } from '@/constants/category';
 import { SHOW_LOCATION } from '@/constants/building';
 import { getLabel, padNumber } from '@/utils/labelHelper';
 import { formatScheduleDate } from '@/utils/dateHelper';
+import { mapSnsUrls } from '@/utils/snsHelper';
 
 import Header from '@/components/Header';
 import ScrapButton from '@/components/ScrapButton';
@@ -85,10 +86,7 @@ const MyShowPage = () => {
   const locationName = show.location
     ? `${getLabel(show.location.building, SHOW_LOCATION)} ${padNumber(show.location.number)}`
     : '';
-  const snsLinks = {
-    instagram: show.sns?.find((url) => url.includes('instagram')),
-    kakaotalk: show.sns?.find((url) => url.includes('kakao')),
-  };
+  const snsLinks = mapSnsUrls(show.sns);
 
   return (
     <>

--- a/src/pages/admin/MyShowPage.jsx
+++ b/src/pages/admin/MyShowPage.jsx
@@ -91,8 +91,8 @@ const MyShowPage = () => {
   };
 
   return (
-    <div className="relative">
-      <Header className="absolute top-0" left="back" right="edit" background="white" />
+    <>
+      <Header left="back" right="edit" background="white" />
       <img
         src={show.thumbnail || '/images/default-image-large.png'}
         className="mt-18 flex aspect-49/30 w-full items-center justify-center object-cover"
@@ -277,7 +277,7 @@ const MyShowPage = () => {
       </div>
 
       {showModal && <ImageModal image={selectedImage} onClose={() => setShowModal(false)} />}
-    </div>
+    </>
   );
 };
 

--- a/src/utils/snsHelper.js
+++ b/src/utils/snsHelper.js
@@ -1,0 +1,25 @@
+/**
+ * SNS URL 매핑 유틸리티
+ */
+
+/**
+ * SNS URL 배열을 플랫폼별로 매핑
+ * URL에 특정 키워드가 포함되어 있으면 해당 SNS로 매핑하고,
+ * 매칭되지 않으면 null 반환
+ *
+ * @param {string[]} snsUrls - SNS URL 배열
+ * @returns {{ instagram: string | null, kakaotalk: string | null }}
+ */
+export const mapSnsUrls = (snsUrls) => {
+  if (!snsUrls || !Array.isArray(snsUrls)) {
+    return {
+      instagram: null,
+      kakaotalk: null,
+    };
+  }
+
+  return {
+    instagram: snsUrls.find((url) => url?.toLowerCase().includes('insta')) || null,
+    kakaotalk: snsUrls.find((url) => url?.toLowerCase().includes('kakao')) || null,
+  };
+};


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->

- close #114

<br />

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

부스 및 공연 상세 정보 조회 API를 연동하고, 데이터 표시 방식을 개선했습니다.
- `NoticePage`: 로딩 처리 개선, 페이지 로드 시 최상단 이동 useEffect 추가
- `MyBoothPage`, `MyShowPage`: 불필요한 Header 스타일링 삭제
- `BoothDetailSheet`, `ShowDetailSheet`: 퍼블리싱 & api 연결
- `snsHelper`: sns 매핑 유틸 함수 추가 (`MyBoothPage`, `MyShowPage`, `BoothDetailSheet`, `ShowDetailSheet`에서 사용)

<br />

## 📸 UI 작업 시

<!-- 이미지 or 영상 or 프리뷰 링크 첨부 -->
<!-- 프리뷰 링크에 해당 페이지의 라우트 경로까지 포함하여 작성 -->
- https://14th-ewha-festival-front-78oh28uuy-yxpjseos-projects.vercel.app/map/booths/BOOTH_GOODS_01
- https://14th-ewha-festival-front-78oh28uuy-yxpjseos-projects.vercel.app/map/shows/SHOW_01

<br />

## 💬 To. Reviewer (선택)

<br />

## ✅ 체크 리스트

- [x] main 브랜치 pull 완료
- [x] Reviewers 설정
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정
