### PR TITLE
기존 api 호출 코드를 tanstack query로 리팩토링

### DIFF
--- a/src/components/Card/BoothCard.jsx
+++ b/src/components/Card/BoothCard.jsx
@@ -30,7 +30,7 @@ const BoothCard = ({ booth, onClick }) => {
   return (
     <div
       onClick={onClick}
-      className="g-0 flex w-full flex-col items-start border-b border-zinc-200 bg-white py-5"
+      className="g-0 flex w-full cursor-pointer flex-col items-start border-b border-zinc-200 bg-white py-5"
     >
       {/* 부스명 및 위치 */}
       <div className="flex w-full items-start justify-between p-0">

--- a/src/components/Card/ImageCard.jsx
+++ b/src/components/Card/ImageCard.jsx
@@ -4,9 +4,12 @@
 
 import React from 'react';
 
-const ImageCard = ({ image, name }) => {
+const ImageCard = ({ image, name, onClick }) => {
   return (
-    <div className="flex w-21 shrink-0 flex-col items-start gap-1.5">
+    <div
+      onClick={onClick}
+      className="flex w-21 shrink-0 cursor-pointer flex-col items-start gap-1.5"
+    >
       <img
         src={image || '/images/default-image-xsmall.png'}
         alt={name}

--- a/src/components/Card/ShowCard.jsx
+++ b/src/components/Card/ShowCard.jsx
@@ -27,7 +27,7 @@ const ShowCard = ({ show, onClick }) => {
   return (
     <div
       onClick={onClick}
-      className="flex w-full items-start gap-4 border-b border-zinc-200 bg-white py-5"
+      className="flex w-full cursor-pointer items-start gap-4 border-b border-zinc-200 bg-white py-5"
     >
       {/* 공연 이미지 */}
       <img

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -2,57 +2,18 @@
  * 전역 로딩 컴포넌트
  */
 
-import { useState, useEffect } from 'react';
 import useLoadingStore from '@/store/useLoadingStore';
+import LoadingSpinner from '@/components/LoadingSpinner';
 
 const GlobalLoading = () => {
   const isLoading = useLoadingStore((state) => state.isLoading);
-  const [dots, setDots] = useState(1);
-  const [rotation, setRotation] = useState(0);
-
-  useEffect(() => {
-    if (!isLoading) return;
-
-    const dotsInterval = setInterval(() => {
-      setDots((prev) => (prev >= 3 ? 1 : prev + 1));
-    }, 1000);
-
-    const rotationInterval = setInterval(() => {
-      setRotation((prev) => prev + 120);
-    }, 1000);
-
-    return () => {
-      clearInterval(dotsInterval);
-      clearInterval(rotationInterval);
-    };
-  }, [isLoading]);
 
   if (!isLoading) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="reactive-width mx-auto flex h-full items-center justify-center overflow-hidden">
-        <div className="flex flex-col items-center gap-4">
-          {/* 로딩 스피너 */}
-          <div className="relative inline-block">
-            <img
-              src="/icons/loading-spinner.svg"
-              alt="loading-spinner"
-              className="transition-transform duration-1000 ease-linear"
-              style={{ transform: `rotate(${rotation}deg)` }}
-            />
-            <img
-              src="/icons/loading-tail.svg"
-              alt="loading-tail"
-              className="absolute top-13 right-10 w-[376.928px] max-w-none"
-            />
-          </div>
-
-          {/* 로딩 텍스트 */}
-          <p className="text-sm font-medium text-emerald-600">
-            잠시만 기다려주세요{'.'.repeat(dots)}
-          </p>
-        </div>
+        <LoadingSpinner />
       </div>
     </div>
   );

--- a/src/components/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner.jsx
@@ -1,0 +1,46 @@
+/**
+ * 로딩 스피너 컴포넌트 (인라인용)
+ */
+
+import { useState, useEffect } from 'react';
+
+const LoadingSpinner = () => {
+  const [dots, setDots] = useState(1);
+  const [rotation, setRotation] = useState(0);
+
+  useEffect(() => {
+    const dotsInterval = setInterval(() => {
+      setDots((prev) => (prev >= 3 ? 1 : prev + 1));
+    }, 1000);
+
+    const rotationInterval = setInterval(() => {
+      setRotation((prev) => prev + 120);
+    }, 1000);
+
+    return () => {
+      clearInterval(dotsInterval);
+      clearInterval(rotationInterval);
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="relative inline-block">
+        <img
+          src="/icons/loading-spinner.svg"
+          alt="loading-spinner"
+          className="transition-transform duration-1000 ease-linear"
+          style={{ transform: `rotate(${rotation}deg)` }}
+        />
+        <img
+          src="/icons/loading-tail.svg"
+          alt="loading-tail"
+          className="absolute top-13 right-10 w-[376.928px] max-w-none"
+        />
+      </div>
+      <p className="text-sm font-medium text-emerald-600">잠시만 기다려주세요{'.'.repeat(dots)}</p>
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/src/constants/building.js
+++ b/src/constants/building.js
@@ -15,5 +15,4 @@ export const BOOTH_LOCATION = [
 export const SHOW_LOCATION = [
   { value: 'STUDENT_UNION', label: '학생문화관' },
   { value: 'GRASS_GROUND', label: '잔디광장' },
-  { value: 'SPORT_TRACK', label: '스포츠트랙' },
 ];

--- a/src/features/booth/BoothDetailSheet.jsx
+++ b/src/features/booth/BoothDetailSheet.jsx
@@ -107,7 +107,7 @@ const BoothDetailSheet = () => {
                   <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
                     {booth.name || '부스명'}
                   </h2>
-                  <ScrapButton count={booth.scraps_count} />
+                  <ScrapButton id={id} type="booth" initialScrapped={booth.is_scrapped} count={booth.scraps_count} />
                 </div>
 
                 {(categoryText || booth.is_ongoing !== undefined) && (

--- a/src/features/booth/BoothDetailSheet.jsx
+++ b/src/features/booth/BoothDetailSheet.jsx
@@ -7,7 +7,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import useAlertStore from '@/store/useAlertStore';
 import useBottomsheetStore from '@/store/useBottomsheetStore';
 
-import { BoothAPI } from '@/apis';
+import { useBoothDetail } from '@/hooks/useBoothDetail';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import { BOOTH_CATEGORY } from '@/constants/category';
 import { BOOTH_LOCATION } from '@/constants/building';
 import { getLabel, padNumber } from '@/utils/labelHelper';
@@ -31,36 +32,26 @@ const BoothDetailSheet = () => {
   const closeAlert = useAlertStore((s) => s.closeAlert);
   const isFull = useBottomsheetStore((s) => s.isFull());
 
-  const [booth, setBooth] = useState(null);
+  const { data: booth, error, isLoading } = useBoothDetail(id);
   const [showModal, setShowModal] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
   const [selectedImage, setSelectedImage] = useState(null);
 
   useEffect(() => {
-    const fetchBoothDetail = async () => {
-      try {
-        const data = await BoothAPI.getBoothById(id);
-        setBooth(data);
-      } catch (error) {
-        console.error('부스 정보를 불러오는데 실패했습니다:', error);
-        openAlert({
-          variant: 'error',
-          title: '오류',
-          text: '부스 정보를 불러올 수 없습니다.',
-          onConfirm: () => {
-            closeAlert();
-            navigate(-1);
-          },
-        });
-      }
-    };
+    if (!error) return;
+    console.error('부스 정보를 불러오는데 실패했습니다:', error);
+    openAlert({
+      variant: 'error',
+      title: '오류',
+      text: '부스 정보를 불러올 수 없습니다.',
+      onConfirm: () => {
+        closeAlert();
+        navigate(-1);
+      },
+    });
+  }, [error]);
 
-    if (id) {
-      fetchBoothDetail();
-    }
-  }, [id]);
-
-  if (!booth) {
+  if (!isLoading && !booth) {
     return null;
   }
 
@@ -68,16 +59,17 @@ const BoothDetailSheet = () => {
     navigate(`/admin/booth/${id}/notice`);
   };
 
-  const categoryText = booth.category?.map((cat) => getLabel(cat, BOOTH_CATEGORY)).join(', ') || '';
+  const categoryText =
+    booth?.category?.map((cat) => getLabel(cat, BOOTH_CATEGORY)).join(', ') || '';
   const scheduleText =
-    booth.schedule?.map((s) => {
+    booth?.schedule?.map((s) => {
       const formattedDate = formatScheduleDate(s.date);
       return `${formattedDate} ${s.time}`;
     }) || [];
-  const locationName = booth.location
+  const locationName = booth?.location
     ? `${getLabel(booth.location.building, BOOTH_LOCATION)} ${padNumber(booth.location.number)}`
     : '';
-  const snsLinks = mapSnsUrls(booth.sns);
+  const snsLinks = mapSnsUrls(booth?.sns);
 
   return (
     <>
@@ -85,7 +77,12 @@ const BoothDetailSheet = () => {
         <Header left="back" background="transparent" />
       </div>
       <BottomsheetDrag>
-        {isFull && (
+        {isLoading && (
+          <div className="flex h-full items-center justify-center">
+            <LoadingSpinner />
+          </div>
+        )}
+        {!isLoading && isFull && (
           <>
             <Header left="back" isSheet />
             <img
@@ -101,186 +98,188 @@ const BoothDetailSheet = () => {
           </>
         )}
 
-        <div className="flex w-full flex-col items-center gap-9 pt-5">
-          {/* 부스 설명 */}
-          <div className="flex w-full flex-col gap-6 self-stretch px-5">
-            <div className="flex w-full flex-col items-start gap-2 self-stretch">
-              <div className="flex w-full items-center justify-between self-stretch">
-                <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
-                  {booth.name || '부스명'}
-                </h2>
-                <ScrapButton count={booth.scraps_count} />
-              </div>
-
-              {(categoryText || booth.is_ongoing !== undefined) && (
-                <div className="flex items-center gap-1">
-                  {categoryText && (
-                    <p className="text-sm leading-5 font-normal tracking-normal text-zinc-500">
-                      {categoryText}
-                    </p>
-                  )}
-
-                  {booth.is_ongoing !== undefined && (
-                    <>
-                      {categoryText && <img src="/icons/icon-eclipse-gray.svg" />}
-                      <Badge state={booth.is_ongoing ? 'operating' : 'closed'} size="md" />
-                    </>
-                  )}
+        {!isLoading && (
+          <div className="flex w-full flex-col items-center gap-9 pt-5">
+            {/* 부스 설명 */}
+            <div className="flex w-full flex-col gap-6 self-stretch px-5">
+              <div className="flex w-full flex-col items-start gap-2 self-stretch">
+                <div className="flex w-full items-center justify-between self-stretch">
+                  <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
+                    {booth.name || '부스명'}
+                  </h2>
+                  <ScrapButton count={booth.scraps_count} />
                 </div>
-              )}
 
-              {booth.description && (
-                <p className="line-clamp-2 max-h-10 self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
-                  {booth.description}
-                </p>
-              )}
-            </div>
+                {(categoryText || booth.is_ongoing !== undefined) && (
+                  <div className="flex items-center gap-1">
+                    {categoryText && (
+                      <p className="text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                        {categoryText}
+                      </p>
+                    )}
 
-            <Divider />
-
-            <div className="flex-start flex flex-col gap-4 self-stretch">
-              {/* 시간 */}
-              <div className="flex items-start gap-4">
-                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
-                  시간
-                </h3>
-                <div className="flex flex-col items-start gap-0.5">
-                  {scheduleText.length > 0 ? (
-                    scheduleText.map((t, i) => (
-                      <h3
-                        key={i}
-                        className="text-sm leading-5 font-normal tracking-normal text-zinc-800"
-                      >
-                        {t}
-                      </h3>
-                    ))
-                  ) : (
-                    <h3 className="text-sm leading-5 font-normal tracking-normal text-zinc-800">
-                      -
-                    </h3>
-                  )}
-                </div>
-              </div>
-
-              {/* 위치 */}
-              <div className="flex items-start gap-4">
-                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
-                  위치
-                </h3>
-                <div className="flex flex-col items-start gap-1.5">
-                  <div className="flex items-center gap-1.5">
-                    <button
-                      className={`text-sm leading-5 font-medium tracking-normal text-zinc-800 ${
-                        locationName
-                          ? 'underline decoration-solid underline-offset-2'
-                          : 'cursor-default'
-                      }`}
-                    >
-                      {locationName || '-'}
-                    </button>
-
-                    {booth.roadview && (
+                    {booth.is_ongoing !== undefined && (
                       <>
-                        <img src="/icons/icon-eclipse-gray.svg" />
-                        <button
-                          className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
-                          onClick={() => {
-                            setSelectedImage(booth.roadview);
-                            setShowModal(true);
-                          }}
-                        >
-                          로드뷰
-                        </button>
+                        {categoryText && <img src="/icons/icon-eclipse-gray.svg" />}
+                        <Badge state={booth.is_ongoing ? 'operating' : 'closed'} size="md" />
                       </>
                     )}
                   </div>
+                )}
 
-                  {booth.location_description && (
-                    <p className="text-xs leading-4 font-normal tracking-normal text-zinc-500">
-                      {booth.location_description}
-                    </p>
-                  )}
-                </div>
+                {booth.description && (
+                  <p className="line-clamp-2 max-h-10 self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                    {booth.description}
+                  </p>
+                )}
               </div>
 
-              {/* SNS */}
-              <div className="flex items-start gap-4">
-                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
-                  SNS
-                </h3>
-                <div className="flex items-center gap-2.5">
-                  {snsLinks.instagram && (
-                    <img
-                      src="/icons/logo-instagramcolor.svg"
-                      className="h-7 w-7 cursor-pointer rounded-md"
-                      onClick={() => window.open(snsLinks.instagram, '_blank')}
-                    />
-                  )}
+              <Divider />
 
-                  {snsLinks.kakaotalk && (
-                    <img
-                      src="/icons/logo-kakaotalkcolor.svg"
-                      className="h-7 w-7 cursor-pointer rounded-md"
-                      onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
-                    />
-                  )}
+              <div className="flex-start flex flex-col gap-4 self-stretch">
+                {/* 시간 */}
+                <div className="flex items-start gap-4">
+                  <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                    시간
+                  </h3>
+                  <div className="flex flex-col items-start gap-0.5">
+                    {scheduleText.length > 0 ? (
+                      scheduleText.map((t, i) => (
+                        <h3
+                          key={i}
+                          className="text-sm leading-5 font-normal tracking-normal text-zinc-800"
+                        >
+                          {t}
+                        </h3>
+                      ))
+                    ) : (
+                      <h3 className="text-sm leading-5 font-normal tracking-normal text-zinc-800">
+                        -
+                      </h3>
+                    )}
+                  </div>
+                </div>
 
-                  {!snsLinks.instagram && !snsLinks.kakaotalk && (
-                    <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
-                  )}
+                {/* 위치 */}
+                <div className="flex items-start gap-4">
+                  <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                    위치
+                  </h3>
+                  <div className="flex flex-col items-start gap-1.5">
+                    <div className="flex items-center gap-1.5">
+                      <button
+                        className={`text-sm leading-5 font-medium tracking-normal text-zinc-800 ${
+                          locationName
+                            ? 'underline decoration-solid underline-offset-2'
+                            : 'cursor-default'
+                        }`}
+                      >
+                        {locationName || '-'}
+                      </button>
+
+                      {booth.roadview && (
+                        <>
+                          <img src="/icons/icon-eclipse-gray.svg" />
+                          <button
+                            className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
+                            onClick={() => {
+                              setSelectedImage(booth.roadview);
+                              setShowModal(true);
+                            }}
+                          >
+                            로드뷰
+                          </button>
+                        </>
+                      )}
+                    </div>
+
+                    {booth.location_description && (
+                      <p className="text-xs leading-4 font-normal tracking-normal text-zinc-500">
+                        {booth.location_description}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* SNS */}
+                <div className="flex items-start gap-4">
+                  <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                    SNS
+                  </h3>
+                  <div className="flex items-center gap-2.5">
+                    {snsLinks.instagram && (
+                      <img
+                        src="/icons/logo-instagramcolor.svg"
+                        className="h-7 w-7 cursor-pointer rounded-md"
+                        onClick={() => window.open(snsLinks.instagram, '_blank')}
+                      />
+                    )}
+
+                    {snsLinks.kakaotalk && (
+                      <img
+                        src="/icons/logo-kakaotalkcolor.svg"
+                        className="h-7 w-7 cursor-pointer rounded-md"
+                        onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
+                      />
+                    )}
+
+                    {!snsLinks.instagram && !snsLinks.kakaotalk && (
+                      <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          {/* 공지 */}
-          <div className="w-full px-5">
-            {booth.latest_notice ? (
-              <NoticeCard
-                title={booth.latest_notice.title}
-                onClick={goNoticePage}
-                style={{ cursor: 'pointer' }}
-              />
-            ) : (
-              <NoticeCard title="등록된 공지가 없어요." />
-            )}
-          </div>
-
-          {/* 리스트 */}
-          <div className="flex w-full flex-col items-center gap-2 self-stretch px-5">
-            <Tab
-              variant="underline"
-              tabs={['리스트']}
-              activeIndex={activeTab}
-              onChange={(index) => setActiveTab(index)}
-            />
-            <div className="flex w-full flex-col items-center self-stretch">
-              {activeTab === 0 && (
-                <div className="pb-36">
-                  {booth.product && booth.product.length > 0 ? (
-                    booth.product.map((item) => (
-                      <MenuCard
-                        key={item.id}
-                        name={item.name}
-                        description={item.description}
-                        image={item.image}
-                        price={item.price}
-                        onImageClick={(img) => {
-                          setSelectedImage(img);
-                          setShowModal(true);
-                        }}
-                      />
-                    ))
-                  ) : (
-                    <div className="flex w-full items-center justify-center self-stretch py-20 text-center text-base leading-6 font-normal tracking-normal text-zinc-300">
-                      등록된 내용이 없어요.
-                    </div>
-                  )}
-                </div>
+            {/* 공지 */}
+            <div className="w-full px-5">
+              {booth.latest_notice ? (
+                <NoticeCard
+                  title={booth.latest_notice.title}
+                  onClick={goNoticePage}
+                  style={{ cursor: 'pointer' }}
+                />
+              ) : (
+                <NoticeCard title="등록된 공지가 없어요." />
               )}
             </div>
+
+            {/* 리스트 */}
+            <div className="flex w-full flex-col items-center gap-2 self-stretch px-5">
+              <Tab
+                variant="underline"
+                tabs={['리스트']}
+                activeIndex={activeTab}
+                onChange={(index) => setActiveTab(index)}
+              />
+              <div className="flex w-full flex-col items-center self-stretch">
+                {activeTab === 0 && (
+                  <div className="pb-36">
+                    {booth.product && booth.product.length > 0 ? (
+                      booth.product.map((item) => (
+                        <MenuCard
+                          key={item.id}
+                          name={item.name}
+                          description={item.description}
+                          image={item.image}
+                          price={item.price}
+                          onImageClick={(img) => {
+                            setSelectedImage(img);
+                            setShowModal(true);
+                          }}
+                        />
+                      ))
+                    ) : (
+                      <div className="flex w-full items-center justify-center self-stretch py-20 text-center text-base leading-6 font-normal tracking-normal text-zinc-300">
+                        등록된 내용이 없어요.
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
-        </div>
+        )}
         {showModal && <ImageModal image={selectedImage} onClose={() => setShowModal(false)} />}
       </BottomsheetDrag>
     </>

--- a/src/features/show/ShowDetailSheet.jsx
+++ b/src/features/show/ShowDetailSheet.jsx
@@ -111,7 +111,7 @@ const ShowDetailSheet = () => {
                 <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
                   {show.name || '공연명'}
                 </h2>
-                <ScrapButton count={show.scraps_count} />
+                <ScrapButton id={id} type="show" initialScrapped={show.is_scrapped} count={show.scraps_count} />
               </div>
 
               {(categoryText || show.is_ongoing !== undefined) && (

--- a/src/features/show/ShowDetailSheet.jsx
+++ b/src/features/show/ShowDetailSheet.jsx
@@ -7,7 +7,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import useAlertStore from '@/store/useAlertStore';
 import useBottomsheetStore from '@/store/useBottomsheetStore';
 
-import { ShowAPI } from '@/apis';
+import { useShowDetail } from '@/hooks/useShowDetail';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import { SHOW_CATEGORY } from '@/constants/category';
 import { SHOW_LOCATION } from '@/constants/building';
 import { getLabel, padNumber } from '@/utils/labelHelper';
@@ -31,36 +32,26 @@ const ShowDetailSheet = () => {
   const closeAlert = useAlertStore((s) => s.closeAlert);
   const isFull = useBottomsheetStore((s) => s.isFull());
 
-  const [show, setShow] = useState(null);
+  const { data: show, error, isLoading } = useShowDetail(id);
   const [showModal, setShowModal] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
   const [selectedImage, setSelectedImage] = useState(null);
 
   useEffect(() => {
-    const fetchShowDetail = async () => {
-      try {
-        const data = await ShowAPI.getShowById(id);
-        setShow(data);
-      } catch (error) {
-        console.error('공연 정보를 불러오는데 실패했습니다:', error);
-        openAlert({
-          variant: 'error',
-          title: '오류',
-          text: '공연 정보를 불러올 수 없습니다.',
-          onConfirm: () => {
-            closeAlert();
-            navigate(-1);
-          },
-        });
-      }
-    };
+    if (!error) return;
+    console.error('공연 정보를 불러오는데 실패했습니다:', error);
+    openAlert({
+      variant: 'error',
+      title: '오류',
+      text: '공연 정보를 불러올 수 없습니다.',
+      onConfirm: () => {
+        closeAlert();
+        navigate(-1);
+      },
+    });
+  }, [error]);
 
-    if (id) {
-      fetchShowDetail();
-    }
-  }, [id]);
-
-  if (!show) {
+  if (!isLoading && !show) {
     return null;
   }
 
@@ -74,16 +65,16 @@ const ShowDetailSheet = () => {
     return 'closed'; // 공연 종료
   };
 
-  const categoryText = show.category ? getLabel(show.category, SHOW_CATEGORY) : '';
+  const categoryText = show?.category ? getLabel(show.category, SHOW_CATEGORY) : '';
   const scheduleText =
-    show.schedule?.map((s) => {
+    show?.schedule?.map((s) => {
       const formattedDate = formatScheduleDate(s.date);
       return `${formattedDate} ${s.time}`;
     }) || [];
-  const locationName = show.location
+  const locationName = show?.location
     ? `${getLabel(show.location.building, SHOW_LOCATION)} ${padNumber(show.location.number)}`
     : '';
-  const snsLinks = mapSnsUrls(show.sns);
+  const snsLinks = mapSnsUrls(show?.sns);
 
   return (
     <>
@@ -91,7 +82,12 @@ const ShowDetailSheet = () => {
         <Header left="back" background="transparent" />
       </div>
       <BottomsheetDrag>
-        {isFull && (
+        {isLoading && (
+          <div className="flex h-full items-center justify-center">
+            <LoadingSpinner />
+          </div>
+        )}
+        {!isLoading && isFull && (
           <>
             <Header left="back" isSheet />
             <img
@@ -107,7 +103,7 @@ const ShowDetailSheet = () => {
           </>
         )}
 
-        <div className="flex w-full flex-col items-center gap-9 pt-5">
+        {!isLoading && <div className="flex w-full flex-col items-center gap-9 pt-5">
           {/* 부스 설명 */}
           <div className="flex w-full flex-col gap-6 self-stretch px-5">
             <div className="flex w-full flex-col items-start gap-2 self-stretch">
@@ -274,7 +270,7 @@ const ShowDetailSheet = () => {
               )}
             </div>
           </div>
-        </div>
+        </div>}
 
         {showModal && <ImageModal image={selectedImage} onClose={() => setShowModal(false)} />}
       </BottomsheetDrag>

--- a/src/hooks/useBoothDetail.js
+++ b/src/hooks/useBoothDetail.js
@@ -11,6 +11,7 @@ export const useBoothDetail = (id) => {
     queryFn: () => BoothAPI.getBoothById(id),
     enabled: !!id,
     staleTime: 1000 * 60 * 5, // 5분
+    select: (data) => ({ ...data, is_scrapped: data.is_scraped }),
   });
 };
 

--- a/src/hooks/useBoothDetail.js
+++ b/src/hooks/useBoothDetail.js
@@ -1,0 +1,23 @@
+/**
+ * 부스 상세 조회 hook
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { BoothAPI } from '@/apis';
+
+export const useBoothDetail = (id) => {
+  return useQuery({
+    queryKey: ['booth', id],
+    queryFn: () => BoothAPI.getBoothById(id),
+    enabled: !!id,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+};
+
+export const useBoothNotices = (id) => {
+  return useQuery({
+    queryKey: ['notices', id],
+    queryFn: () => BoothAPI.getBoothNotices(id),
+    enabled: !!id,
+  });
+};

--- a/src/hooks/useMyProfile.js
+++ b/src/hooks/useMyProfile.js
@@ -1,0 +1,18 @@
+/**
+ * 내 프로필 조회 hook
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { MeAPI } from '@/apis';
+import useAuthStore from '@/store/useAuthStore';
+
+export const useMyProfile = () => {
+  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
+
+  return useQuery({
+    queryKey: ['myProfile'],
+    queryFn: MeAPI.getMyProfile,
+    enabled: isLoggedIn,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+};

--- a/src/hooks/useShowDetail.js
+++ b/src/hooks/useShowDetail.js
@@ -1,0 +1,23 @@
+/**
+ * 공연 상세 조회 hook
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { ShowAPI } from '@/apis';
+
+export const useShowDetail = (id) => {
+  return useQuery({
+    queryKey: ['show', id],
+    queryFn: () => ShowAPI.getShowById(id),
+    enabled: !!id,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+};
+
+export const useShowNotices = (id) => {
+  return useQuery({
+    queryKey: ['notices', id],
+    queryFn: () => ShowAPI.getShowNotices(id),
+    enabled: !!id,
+  });
+};

--- a/src/hooks/useShowDetail.js
+++ b/src/hooks/useShowDetail.js
@@ -11,6 +11,7 @@ export const useShowDetail = (id) => {
     queryFn: () => ShowAPI.getShowById(id),
     enabled: !!id,
     staleTime: 1000 * 60 * 5, // 5분
+    select: (data) => ({ ...data, is_scrapped: data.is_scraped }),
   });
 };
 

--- a/src/pages/NoticePage.jsx
+++ b/src/pages/NoticePage.jsx
@@ -2,8 +2,9 @@
  * 부스/공연 공지 페이지
  */
 
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import useAlertStore from '@/store/useAlertStore';
 import useLoadingStore from '@/store/useLoadingStore';
 
@@ -15,56 +16,43 @@ import { Accordion } from '@/components/Accordion';
 const NoticePage = () => {
   const { id } = useParams();
   const navigate = useNavigate();
-  const [notices, setNotices] = useState([]);
   const openAlert = useAlertStore((s) => s.openAlert);
   const closeAlert = useAlertStore((s) => s.closeAlert);
   const showLoading = useLoadingStore((s) => s.showLoading);
   const hideLoading = useLoadingStore((s) => s.hideLoading);
-  const isLoading = useLoadingStore((s) => s.isLoading);
 
   // ID로 부스/공연 구분
   const isBooth = id?.startsWith('BOOTH_');
   const isShow = id?.startsWith('SHOW_');
+
+  const { data: notices = [], error, isLoading } = useQuery({
+    queryKey: ['notices', id],
+    queryFn: () => (isBooth ? BoothAPI.getBoothNotices(id) : ShowAPI.getShowNotices(id)),
+    enabled: !!id && (isBooth || isShow),
+  });
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
   useEffect(() => {
-    const fetchNotices = async () => {
-      try {
-        showLoading();
-        let data;
+    if (isLoading) showLoading();
+    else hideLoading();
+  }, [isLoading]);
 
-        if (isBooth) {
-          data = await BoothAPI.getBoothNotices(id);
-        } else if (isShow) {
-          data = await ShowAPI.getShowNotices(id);
-        } else {
-          throw new Error('잘못된 ID 형식입니다.');
-        }
-
-        setNotices(data);
-      } catch (error) {
-        console.error('공지 정보를 불러오는데 실패했습니다:', error);
-        openAlert({
-          variant: 'error',
-          title: '오류',
-          text: '공지 정보를 불러올 수 없습니다.',
-          onConfirm: () => {
-            closeAlert();
-            navigate(-1);
-          },
-        });
-      } finally {
-        hideLoading();
-      }
-    };
-
-    if (id) {
-      fetchNotices();
-    }
-  }, [id]);
+  useEffect(() => {
+    if (!error) return;
+    console.error('공지 정보를 불러오는데 실패했습니다:', error);
+    openAlert({
+      variant: 'error',
+      title: '오류',
+      text: '공지 정보를 불러올 수 없습니다.',
+      onConfirm: () => {
+        closeAlert();
+        navigate(-1);
+      },
+    });
+  }, [error]);
 
   return (
     <>

--- a/src/pages/admin/MyBoothPage.jsx
+++ b/src/pages/admin/MyBoothPage.jsx
@@ -96,7 +96,7 @@ const MyBoothPage = () => {
               <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
                 {booth.name || '부스명'}
               </h2>
-              <ScrapButton count={booth.scraps_count} />
+              <ScrapButton id={id} type="booth" initialScrapped={booth.is_scrapped} count={booth.scraps_count} />
             </div>
 
             {(categoryText || booth.is_ongoing !== undefined) && (

--- a/src/pages/admin/MyBoothPage.jsx
+++ b/src/pages/admin/MyBoothPage.jsx
@@ -7,7 +7,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import useAlertStore from '@/store/useAlertStore';
 import useLoadingStore from '@/store/useLoadingStore';
 
-import { BoothAPI } from '@/apis';
+import { useBoothDetail } from '@/hooks/useBoothDetail';
 import { BOOTH_CATEGORY } from '@/constants/category';
 import { BOOTH_LOCATION } from '@/constants/building';
 import { getLabel, padNumber } from '@/utils/labelHelper';
@@ -31,37 +31,29 @@ const MyBoothPage = () => {
   const showLoading = useLoadingStore((s) => s.showLoading);
   const hideLoading = useLoadingStore((s) => s.hideLoading);
 
-  const [booth, setBooth] = useState(null);
+  const { data: booth, error, isLoading } = useBoothDetail(id);
   const [showModal, setShowModal] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
   const [selectedImage, setSelectedImage] = useState(null);
 
   useEffect(() => {
-    const fetchBoothDetail = async () => {
-      try {
-        showLoading();
-        const data = await BoothAPI.getBoothById(id);
-        setBooth(data);
-      } catch (error) {
-        console.error('부스 정보를 불러오는데 실패했습니다:', error);
-        openAlert({
-          variant: 'error',
-          title: '오류',
-          text: '부스 정보를 불러올 수 없습니다.',
-          onConfirm: () => {
-            closeAlert();
-            navigate(-1);
-          },
-        });
-      } finally {
-        hideLoading();
-      }
-    };
+    if (isLoading) showLoading();
+    else hideLoading();
+  }, [isLoading]);
 
-    if (id) {
-      fetchBoothDetail();
-    }
-  }, [id]);
+  useEffect(() => {
+    if (!error) return;
+    console.error('부스 정보를 불러오는데 실패했습니다:', error);
+    openAlert({
+      variant: 'error',
+      title: '오류',
+      text: '부스 정보를 불러올 수 없습니다.',
+      onConfirm: () => {
+        closeAlert();
+        navigate(-1);
+      },
+    });
+  }, [error]);
 
   if (!booth) {
     return null;

--- a/src/pages/admin/MyShowPage.jsx
+++ b/src/pages/admin/MyShowPage.jsx
@@ -7,7 +7,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import useAlertStore from '@/store/useAlertStore';
 import useLoadingStore from '@/store/useLoadingStore';
 
-import { ShowAPI } from '@/apis';
+import { useShowDetail } from '@/hooks/useShowDetail';
 import { SHOW_CATEGORY } from '@/constants/category';
 import { SHOW_LOCATION } from '@/constants/building';
 import { getLabel, padNumber } from '@/utils/labelHelper';
@@ -31,37 +31,29 @@ const MyShowPage = () => {
   const showLoading = useLoadingStore((s) => s.showLoading);
   const hideLoading = useLoadingStore((s) => s.hideLoading);
 
-  const [show, setShow] = useState(null);
+  const { data: show, error, isLoading } = useShowDetail(id);
   const [showModal, setShowModal] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
   const [selectedImage, setSelectedImage] = useState(null);
 
   useEffect(() => {
-    const fetchShowDetail = async () => {
-      try {
-        showLoading();
-        const data = await ShowAPI.getShowById(id);
-        setShow(data);
-      } catch (error) {
-        console.error('공연 정보를 불러오는데 실패했습니다:', error);
-        openAlert({
-          variant: 'error',
-          title: '오류',
-          text: '공연 정보를 불러올 수 없습니다.',
-          onConfirm: () => {
-            closeAlert();
-            navigate(-1);
-          },
-        });
-      } finally {
-        hideLoading();
-      }
-    };
+    if (isLoading) showLoading();
+    else hideLoading();
+  }, [isLoading]);
 
-    if (id) {
-      fetchShowDetail();
-    }
-  }, [id]);
+  useEffect(() => {
+    if (!error) return;
+    console.error('공연 정보를 불러오는데 실패했습니다:', error);
+    openAlert({
+      variant: 'error',
+      title: '오류',
+      text: '공연 정보를 불러올 수 없습니다.',
+      onConfirm: () => {
+        closeAlert();
+        navigate(-1);
+      },
+    });
+  }, [error]);
 
   if (!show) {
     return null;

--- a/src/pages/admin/MyShowPage.jsx
+++ b/src/pages/admin/MyShowPage.jsx
@@ -102,7 +102,7 @@ const MyShowPage = () => {
               <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
                 {show.name || '공연명'}
               </h2>
-              <ScrapButton count={show.scraps_count} />
+              <ScrapButton id={id} type="show" initialScrapped={show.is_scrapped} count={show.scraps_count} />
             </div>
 
             {(categoryText || show.is_ongoing !== undefined) && (

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -2,11 +2,12 @@
  * 마이페이지
  */
 
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AuthAPI, MeAPI } from '@/apis';
+import { AuthAPI } from '@/apis';
 import useAuthStore from '@/store/useAuthStore';
 import useAlertStore from '@/store/useAlertStore';
+import { useMyProfile } from '@/hooks/useMyProfile';
 import Header from '@/components/Header';
 import Button from '@/components/Button';
 import ImageCard from '@/components/Card/ImageCard';
@@ -14,13 +15,11 @@ import ImageCard from '@/components/Card/ImageCard';
 const MyPage = () => {
   const navigate = useNavigate();
   const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
-  const nickname = useAuthStore((s) => s.nickname);
-  const setNickname = useAuthStore((s) => s.setNickname);
   const logout = useAuthStore((s) => s.logout);
   const openLoginSheet = useAuthStore((s) => s.openLoginSheet);
   const openAlert = useAlertStore((s) => s.openAlert);
   const closeAlert = useAlertStore((s) => s.closeAlert);
-  const [myData, setMyData] = useState(null);
+  const { data: myData, error } = useMyProfile();
 
   const goScrap = () => {
     if (!isLoggedIn) {
@@ -72,37 +71,27 @@ const MyPage = () => {
   }, []);
 
   useEffect(() => {
-    const fetchMyData = async () => {
-      if (isLoggedIn) {
-        try {
-          const data = await MeAPI.getMyProfile();
-          setMyData(data);
-          setNickname(data?.nickname);
-        } catch (error) {
-          console.error('마이페이지 데이터 로드 실패:', error);
-
-          // 인증 실패 (401) → 로그아웃 처리
-          if (error?.response?.status === 401) {
-            openAlert({
-              variant: 'error',
-              title: '세션 만료',
-              text: '로그인 세션이 만료되었습니다. 다시 로그인해주세요.',
-              onConfirm: () => {
-                logout();
-                closeAlert();
-                openLoginSheet();
-              },
-            });
-          }
-        }
-      } else {
-        openLoginSheet();
-        setMyData(null);
-      }
-    };
-
-    fetchMyData();
+    if (!isLoggedIn) {
+      openLoginSheet();
+    }
   }, [isLoggedIn]);
+
+  useEffect(() => {
+    if (!error) return;
+    console.error('마이페이지 데이터 로드 실패:', error);
+    if (error?.response?.status === 401) {
+      openAlert({
+        variant: 'error',
+        title: '세션 만료',
+        text: '로그인 세션이 만료되었습니다. 다시 로그인해주세요.',
+        onConfirm: () => {
+          logout();
+          closeAlert();
+          openLoginSheet();
+        },
+      });
+    }
+  }, [error]);
 
   return (
     <>
@@ -113,7 +102,7 @@ const MyPage = () => {
           <div className="flex gap-1">
             {isLoggedIn ? (
               <>
-                <p className="text-emerald-600">{nickname}</p>
+                <p className="text-emerald-600">{myData?.nickname}</p>
                 <p>님</p>
               </>
             ) : (

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -49,6 +49,14 @@ const MyPage = () => {
     navigate(`/admin/show/${showId}`);
   };
 
+  const goScrapDetail = (scrapId) => {
+    if (scrapId?.includes('BOOTH')) {
+      navigate(`/map/booths/${scrapId}`);
+    } else if (scrapId?.includes('SHOW')) {
+      navigate(`/map/shows/${scrapId}`);
+    }
+  };
+
   const handleLogoutClick = () => {
     openAlert({
       variant: 'logout',
@@ -129,7 +137,12 @@ const MyPage = () => {
           {(myData?.recent_scraps?.length ?? 0) > 0 ? (
             <div className="scrollbar-hide flex gap-1.5 overflow-x-auto px-5 whitespace-nowrap">
               {myData.recent_scraps.map((scrap) => (
-                <ImageCard key={scrap.id} name={scrap.name} thumbnail={scrap.thumbnail} />
+                <ImageCard
+                  key={scrap.id}
+                  name={scrap.name}
+                  thumbnail={scrap.thumbnail}
+                  onClick={() => goScrapDetail(scrap.id)}
+                />
               ))}
             </div>
           ) : (

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -141,7 +141,7 @@ const MyPage = () => {
                   key={scrap.id}
                   name={scrap.name}
                   thumbnail={scrap.thumbnail}
-                  onClick={() => goScrapDetail(scrap.id)}
+                  onClick={() => goScrapDetail(scrap.target_id)}
                 />
               ))}
             </div>

--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -10,17 +10,14 @@ const useAuthStore = create(
     (set) => ({
       isLoggedIn: false,
       showLoginSheet: false,
-      nickname: null,
 
       login: () => {
         set({ isLoggedIn: true, showLoginSheet: false });
       },
 
       logout: () => {
-        set({ isLoggedIn: false, nickname: null });
+        set({ isLoggedIn: false });
       },
-
-      setNickname: (nickname) => set({ nickname }),
 
       openLoginSheet: () => set({ showLoginSheet: true }),
       closeLoginSheet: () => set({ showLoginSheet: false }),
@@ -29,7 +26,6 @@ const useAuthStore = create(
       name: 'auth-store',
       partialize: (state) => ({
         isLoggedIn: state.isLoggedIn,
-        nickname: state.nickname,
       }),
     },
   ),


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->

- close #118

<br />

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

### Summary
- `useQuery`를 활용한 커스텀 훅(`useMyProfile`, `useBoothDetail`, `useShowDetail`)을 생성하여 수동 fetch + `useState` 방식을 TanStack Query로 전환
- `MyPage`, `BoothDetailSheet`, `ShowDetailSheet`, `MyBoothPage`, `MyShowPage`, `NoticePage` 데이터 페칭 리팩토링
- `Loading.jsx`에서 스피너 UI를 `LoadingSpinner.jsx`로 분리하여 바텀시트 내 인라인 로딩에도 재사용 가능하도록 개선
- `useAuthStore`에서 닉네임 전역 상태 제거 — `MyPage`에서만 사용되므로 `useMyProfile` 데이터 직접 참조로 대체

### 훅 설명
| 훅 | 위치 | 설명 |
|---|---|---|
| `useMyProfile` | `src/hooks/useMyProfile.js` | 내 프로필 조회, `staleTime: 5분` |
| `useBoothDetail` | `src/hooks/useBoothDetail.js` | 부스 상세 조회, `staleTime: 5분` |
| `useBoothNotices` | `src/hooks/useBoothDetail.js` | 부스 공지 목록 조회 |
| `useShowDetail` | `src/hooks/useShowDetail.js` | 공연 상세 조회, `staleTime: 5분` |
| `useShowNotices` | `src/hooks/useShowDetail.js` | 공연 공지 목록 조회 | 

### 주요 변경 사항
- 수동 `useEffect` fetch → `useQuery` 훅으로 교체 (로딩/에러/캐싱 자동 관리)
- `useAuthStore` 닉네임 관련 상태(`nickname`, `setNickname`) 제거
- `Loading.jsx` → `GlobalLoading` + `LoadingSpinner` 분리 (바텀시트 내 로딩 표시 가능)
- `BoothDetailSheet` / `ShowDetailSheet`: 로딩 중 바텀시트 내부에 `LoadingSpinner` 표시
- `NoticePage`: 부스/공연 ID prefix(`BOOTH_` / `SHOW_`)로 분기하여 `useQuery` 적용  
<br />

## 📸 UI 작업 시

<!-- 이미지 or 영상 or 프리뷰 링크 첨부 -->
<!-- 프리뷰 링크에 해당 페이지의 라우트 경로까지 포함하여 작성 -->

<br />

## 💬 To. Reviewer (선택)

<br />

## ✅ 체크 리스트

- [x] main 브랜치 pull 완료
- [x] Reviewers 설정
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정