### PR TITLE
ScrapPage 퍼블리싱 & api 연결

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import NoticePage from '@/pages/NoticePage';
 
 // 마이
 import MyPage from '@/pages/my/MyPage';
+import ScrapPage from '@/pages/my/ScrapPage';
 
 // 지도
 import MapPage from '@/pages/map/MapPage';
@@ -61,7 +62,7 @@ function App() {
 
           {/* 마이 */}
           <Route path="my" element={<MyPage />} />
-          <Route path="my/scrap" element={<div>Scrap</div>} />
+          <Route path="my/scrap" element={<ScrapPage />} />
 
           {/* 지도 */}
           <Route path="map" element={<MapPage />}>

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -1,31 +1,34 @@
 /**
- * Alert 컴포넌트 ( variant: delete-삭제, logout-로그아웃, error-오류)
+ * Alert 컴포넌트 ( variant: delete-삭제(기본), confirm-확인, error-오류)
  */
 
-const Alert = ({ variant = 'delete', title = '', text, onCancel, onConfirm }) => {
+const Alert = ({
+  variant = 'delete',
+  title = '',
+  text = '',
+  confirmLabel = '확인',
+  onCancel,
+  onConfirm,
+}) => {
   const isDelete = variant === 'delete';
   const isError = variant === 'error';
 
   return (
     <div className="shadow-up-sm z-50 flex w-80 flex-col items-center justify-center gap-4 rounded-2xl bg-white p-6">
       <div
-        className={`flex flex-col items-center justify-center gap-2 ${isDelete ? 'p-0' : 'p-4'}`}
+        className={`flex flex-col items-center justify-center gap-2 ${isDelete || isError ? 'p-0' : 'p-4'}`}
       >
-        {/* 아이콘은 삭제인 경우만 */}
+        {/* 아이콘은 삭제/오류인 경우만 */}
         {(isDelete || isError) && <img src="/icons/icon-alert.svg" />}
 
         {/* 타이틀 */}
         <h2 className="mt-0.5 text-center text-lg leading-6 font-semibold tracking-normal text-zinc-800">
-          {isDelete && `${title} 삭제`}
-          {isError && title}
-          {variant === 'logout' && '로그아웃하시겠어요?'}
+          {isDelete ? `${title} 삭제` : title}
         </h2>
 
         {/* 문구 */}
         <p className="text-center text-sm leading-5 font-normal tracking-normal text-zinc-500">
-          {variant === 'delete' && text}
-          {variant === 'error' && text}
-          {variant === 'logout' && '언제든지 다시 로그인하실 수 있어요.'}
+          {text}
         </p>
       </div>
 
@@ -47,7 +50,7 @@ const Alert = ({ variant = 'delete', title = '', text, onCancel, onConfirm }) =>
             isDelete || isError ? 'bg-red-400 text-white' : 'bg-emerald-600 text-white'
           }`}
         >
-          {isDelete ? '삭제' : '확인'}
+          {isDelete ? '삭제' : confirmLabel}
         </button>
       </div>
     </div>

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -3,7 +3,7 @@
  *
  * @param {Object} props
  * @param {('sm'|'md'|'lg')} [props.size='lg'] - 버튼 크기
- * @param {('bg-green'|'bg-red'|'bg-gray'|'bg-white'|'bg-pink'|'text-black'|'text-gray'|'underline-green'|'underline-gray'|'underline-white')} [props.variant='bg-green'] - 버튼 스타일 variant
+ * @param {('bg-green'|'bg-red'|'bg-gray'|'bg-white'|'bg-pink'|'text-black'|'text-gray'|'underline-green'|'underline-gray'|'underline-lightgray'|'underline-white')} [props.variant='bg-green'] - 버튼 스타일 variant
  * @param {boolean} [props.circle=false] - 둥근 버튼 여부 (true일 경우 둥근 버튼, false이면서 bg있으면 사각형 버튼)
  * @param {boolean} [props.shadow=false] - 그림자 효과 여부
  * @param {boolean} [props.disabled=false] - 비활성화 상태
@@ -31,6 +31,7 @@ const STYLE = {
   'text-gray': 'text-zinc-500',
   'underline-green': 'text-emerald-600 underline underline-offset-2 !p-0',
   'underline-gray': 'text-zinc-500 underline underline-offset-2 !p-0',
+  'underline-lightgray': 'text-zinc-300 underline underline-offset-2 !p-0',
   'underline-white': 'text-white underline underline-offset-2 !p-0',
 };
 

--- a/src/components/DropDown.jsx
+++ b/src/components/DropDown.jsx
@@ -14,7 +14,10 @@ const DropDown = ({ type = 'booth' }) => {
   // 전역 상태에서 현재 타입의 필터 가져오기
   const filters = useFilterStore((state) => state.filters[type]) || {};
   const setFilter = useFilterStore((state) => state.setFilter);
-  const config = filterConfig[type] || {};
+
+  // scrap_ 접두사 제거하여 동일한 config 사용
+  const configType = type?.replace('scrap_', '') || type;
+  const config = filterConfig[configType] || {};
   const options = config.sort || [];
 
   // 스토어의 sort 값 또는 기본값 사용

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -18,7 +18,10 @@ function FilterBar({ type = 'booth' }) {
   const deleteFilter = useFilterStore((state) => state.deleteFilter);
   const openSheet = useFilterSheetStore((state) => state.openSheet);
 
-  const config = filterConfig[type] || {};
+  // scrap_ 접두사 제거하여 동일한 config 사용
+  const configType = type?.replace('scrap_', '') || type;
+  const config = filterConfig[configType] || {};
+
   const { host, category, day, location } = filters;
   const hasActiveFilter = !!(
     (host && host.length > 0) ||

--- a/src/components/ScrapButton.jsx
+++ b/src/components/ScrapButton.jsx
@@ -46,44 +46,64 @@ const ScrapButton = ({
     }
   };
 
+  const scrapQueryKey = type === 'show' ? ['myScrapShows'] : ['myScrapBooths'];
+  const listQueryKey = type === 'show' ? ['shows'] : ['booths'];
+
   // TanStack Query useMutation으로 스크랩 토글
   const mutation = useMutation({
     mutationFn: getToggleFunction(),
 
     // 낙관적 업데이트: API 호출 전 즉시 UI 변경
     onMutate: async () => {
-      const previousScrapped = isScrapped; // 현재 스크랩 상태 백업
-      const previousCount = scrapCount; // 현재 스크랩 수 백업
+      const previousScrapped = isScrapped;
+      const previousCount = scrapCount;
 
       // UI 즉시 업데이트
-      const nextScrapped = !isScrapped;
-      setIsScrapped(nextScrapped);
-      setScrapCount((prev) => (nextScrapped ? prev + 1 : Math.max(0, prev - 1)));
+      setIsScrapped(!isScrapped);
+      setScrapCount((prev) => (!isScrapped ? prev + 1 : Math.max(0, prev - 1)));
 
-      // 롤백을 위해 이전 상태 반환
+      // 스크랩 취소 시: 스크랩 목록 캐시에서 즉시 제거
+      if (isScrapped) {
+        await queryClient.cancelQueries({ queryKey: scrapQueryKey });
+        const previousScrapData = queryClient.getQueryData(scrapQueryKey);
+
+        queryClient.setQueryData(scrapQueryKey, (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              result: page.result.filter((item) => item.id !== id),
+            })),
+          };
+        });
+
+        return { previousScrapped, previousCount, previousScrapData };
+      }
+
       return { previousScrapped, previousCount };
     },
 
-    // 성공 시
-    onSuccess: (data, variables, context) => {
-      // TanStack Query 캐시 무효화 → 데이터 다시 불러오기
-      if (type === 'show') {
-        queryClient.invalidateQueries({ queryKey: ['shows'] });
-      } else {
-        queryClient.invalidateQueries({ queryKey: ['booths'] });
-      }
+    // 성공 시: 서버와 동기화
+    onSuccess: (_data, _variables, context) => {
+      queryClient.invalidateQueries({ queryKey: listQueryKey });
+      queryClient.invalidateQueries({ queryKey: scrapQueryKey });
 
       if (onToggle) onToggle(!context.previousScrapped);
     },
 
     // 실패 시 롤백
-    onError: (error, variables, context) => {
+    onError: (error, _variables, context) => {
       console.error('❌ [ScrapButton] Toggle failed:', error);
 
-      // 이전 상태로 복구
       if (context) {
         setIsScrapped(context.previousScrapped);
         setScrapCount(context.previousCount);
+
+        // 스크랩 목록 캐시도 복원
+        if (context.previousScrapData) {
+          queryClient.setQueryData(scrapQueryKey, context.previousScrapData);
+        }
       }
     },
   });

--- a/src/features/booth/BoothListSheet.jsx
+++ b/src/features/booth/BoothListSheet.jsx
@@ -13,9 +13,9 @@ import { useBooths, useInfiniteScroll } from '@/hooks';
 import Header from '@/components/Header';
 import Tab from '@/components/Tab';
 import FilterBar from '@/components/FilterBar';
-import BoothCard from '@/components/Card/BoothCard';
 import Checkbox from '@/components/Checkbox';
 import DropDown from '@/components/DropDown';
+import BoothCard from '@/components/Card/BoothCard';
 
 const BoothListSheet = () => {
   const isFull = useBottomsheetStore((s) => s.isFull());

--- a/src/features/show/ShowListSheet.jsx
+++ b/src/features/show/ShowListSheet.jsx
@@ -13,9 +13,9 @@ import { useShows, useInfiniteScroll } from '@/hooks';
 import Header from '@/components/Header';
 import Tab from '@/components/Tab';
 import FilterBar from '@/components/FilterBar';
-import ShowCard from '@/components/Card/ShowCard';
 import Checkbox from '@/components/Checkbox';
 import DropDown from '@/components/DropDown';
+import ShowCard from '@/components/Card/ShowCard';
 
 const ShowListSheet = () => {
   const isFull = useBottomsheetStore((s) => s.isFull());

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -6,3 +6,4 @@ export { useSearch } from './useSearch.js';
 export { useBooths } from './useBooths.js';
 export { useShows } from './useShows.js';
 export { useInfiniteScroll } from './useInfiniteScroll.js';
+export { useInfiniteList, buildQueryParams } from './useInfiniteList.js';

--- a/src/hooks/useBooths.js
+++ b/src/hooks/useBooths.js
@@ -2,15 +2,12 @@
  * 부스 목록 조회 hook (무한 스크롤)
  */
 
-import { useMemo } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
 import { BoothAPI } from '@/apis';
 import { BOOTH_CATEGORY } from '@/constants/category';
 import { BOOTH_LOCATION } from '@/constants/building';
 import { FESTIVAL_DAYS } from '@/constants/day';
 import { getLabel, padNumber } from '@/utils/labelHelper';
-
-const LIMIT = 6; // 한 페이지당 6개씩 로드
+import { useInfiniteList } from '@/hooks/useInfiniteList';
 
 /**
  * 부스 목록 조회 (무한 스크롤)
@@ -18,89 +15,15 @@ const LIMIT = 6; // 한 페이지당 6개씩 로드
  * @returns {Object} useInfiniteQuery 결과 + 변환된 booths, totalCount
  */
 export const useBooths = (filters = {}) => {
-  const queryResult = useInfiniteQuery({
-    queryKey: ['booths', filters],
-    queryFn: async ({ pageParam = 0 }) => {
-      const params = buildQueryParams(filters, pageParam);
-      const data = await BoothAPI.getBooths(params);
-
-      // API 응답 데이터를 변환하여 반환
-      return {
-        ...data,
-        result: data.result.map(transformBoothData),
-      };
-    },
-    getNextPageParam: (lastPage, allPages) => {
-      if (lastPage.next) {
-        return allPages.length * LIMIT;
-      }
-      return undefined;
-    },
-    initialPageParam: 0,
-    staleTime: 1000 * 60 * 5, // 5분
+  const { items: booths, totalCount, ...rest } = useInfiniteList({
+    queryKey: 'booths',
+    apiFn: BoothAPI.getBooths,
+    dataKey: 'result',
+    transform: transformBoothData,
+    limit: 6,
+    filters,
   });
-
-  // 모든 페이지의 부스 데이터 합치기
-  const booths = useMemo(() => {
-    return queryResult.data?.pages.flatMap((page) => page.result) || [];
-  }, [queryResult.data]);
-
-  // 전체 부스 개수
-  const totalCount = useMemo(() => {
-    return queryResult.data?.pages[0]?.count || 0;
-  }, [queryResult.data]);
-
-  return {
-    ...queryResult,
-    booths, // 변환된 부스 배열
-    totalCount, // 전체 개수
-  };
-};
-
-/**
- * 필터 객체를 쿼리 파라미터로 변환
- */
-const buildQueryParams = (filters, offset) => {
-  const params = {
-    limit: LIMIT,
-    offset,
-  };
-
-  // 종료 제외 로직
-  // - 체크박스 OFF (excludeEnded=false, 기본): is_ongoing=false 전송 → 종료 포함
-  // - 체크박스 ON (excludeEnded=true): is_ongoing=true 전송 → 종료 제외
-  if (filters.excludeEnded) {
-    params.is_ongoing = true; // 운영 중인 것만
-  } else {
-    params.is_ongoing = false; // 모두 포함
-  }
-
-  // 카테고리 (배열)
-  if (filters.category?.length > 0) {
-    params.category = filters.category;
-  }
-
-  // 위치 (location → building)
-  if (filters.location?.length > 0) {
-    params.building = filters.location;
-  }
-
-  // 주관 (host)
-  if (filters.host?.length > 0) {
-    params.host = filters.host;
-  }
-
-  // 요일 (day → date, YYYY-MM-DD 형식)
-  if (filters.day?.length > 0) {
-    params.date = filters.day;
-  }
-
-  // 정렬 (sort → sorting)
-  if (filters.sort) {
-    params.sorting = filters.sort;
-  }
-
-  return params;
+  return { ...rest, booths, totalCount };
 };
 
 /**
@@ -142,7 +65,7 @@ export const getDaysText = (dates) => {
  * @param {Object} booth - 원본 부스 데이터
  * @returns {Object} - 변환된 부스 데이터 (categoryText, daysText, locationText, badgeState 추가)
  */
-const transformBoothData = (booth) => {
+export const transformBoothData = (booth) => {
   const { category = [], schedule = [], location, is_ongoing, is_scraped, scraps_count } = booth;
 
   // 카테고리 한글 변환

--- a/src/hooks/useInfiniteList.js
+++ b/src/hooks/useInfiniteList.js
@@ -1,0 +1,65 @@
+/**
+ * 무한 스크롤 목록 조회 공용 hook
+ */
+
+import { useMemo } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+/**
+ * 필터 객체를 API 쿼리 파라미터로 변환 (부스/공연/스크랩 공통)
+ */
+export const buildQueryParams = (filters, offset, limit) => {
+  const params = { limit, offset };
+
+  params.is_ongoing = filters.excludeEnded ? true : false;
+
+  if (filters.category?.length > 0) params.category = filters.category;
+  if (filters.location?.length > 0) params.building = filters.location;
+  if (filters.host?.length > 0) params.host = filters.host;
+  if (filters.day?.length > 0) params.date = filters.day;
+  if (filters.sort) params.sorting = filters.sort;
+
+  return params;
+};
+
+/**
+ * 무한 스크롤 목록 조회 공용 hook
+ * @param {string}   queryKey  - TanStack Query 캐시 키
+ * @param {Function} apiFn    - API 호출 함수 (params) => Promise<data>
+ * @param {string}   dataKey  - 응답 객체에서 목록을 꺼낼 키 (예: 'result', 'booths', 'shows')
+ * @param {Function} transform - 각 아이템을 변환하는 함수
+ * @param {number}   limit    - 페이지당 아이템 수
+ * @param {Object}   filters  - 필터 객체
+ * @returns {{ items, totalCount, ...queryResult }}
+ */
+export const useInfiniteList = ({ queryKey, apiFn, dataKey, transform, limit = 6, filters = {} }) => {
+  const queryResult = useInfiniteQuery({
+    queryKey: [queryKey, filters],
+    queryFn: async ({ pageParam = 0 }) => {
+      const params = buildQueryParams(filters, pageParam, limit);
+      const data = await apiFn(params);
+      return {
+        ...data,
+        [dataKey]: (data[dataKey] ?? []).map(transform),
+      };
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.next) return allPages.length * limit;
+      return undefined;
+    },
+    initialPageParam: 0,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const items = useMemo(
+    () => queryResult.data?.pages.flatMap((page) => page[dataKey]) || [],
+    [queryResult.data, dataKey],
+  );
+
+  const totalCount = useMemo(
+    () => queryResult.data?.pages[0]?.count || 0,
+    [queryResult.data],
+  );
+
+  return { ...queryResult, items, totalCount };
+};

--- a/src/hooks/useMyScrap.js
+++ b/src/hooks/useMyScrap.js
@@ -1,0 +1,62 @@
+/**
+ * 내 스크랩 목록 조회 hook (무한 스크롤)
+ */
+
+import { ScrapAPI } from '@/apis';
+import { transformBoothData } from '@/hooks/useBooths';
+import { transformShowData } from '@/hooks/useShows';
+import { useInfiniteList } from '@/hooks/useInfiniteList';
+
+// 스크랩 API 응답 구조:
+// { booths: { counts, next, search_result: [...] }, shows: { counts, next, search_result: [...] } }
+// → useInfiniteList 표준 포맷: { count, next, result: [...] } 으로 정규화
+
+const scrapBoothsApiFn = async (params) => {
+  const data = await ScrapAPI.getMyScrapList(params);
+  return {
+    count: data.booths.counts,
+    next: data.booths.next,
+    result: data.booths.search_result,
+  };
+};
+
+const scrapShowsApiFn = async (params) => {
+  const data = await ScrapAPI.getMyScrapList(params);
+  return {
+    count: data.shows.counts,
+    next: data.shows.next,
+    result: data.shows.search_result,
+  };
+};
+
+export const useMyScrapBooths = (filters = {}) => {
+  const {
+    items: booths,
+    totalCount,
+    ...rest
+  } = useInfiniteList({
+    queryKey: 'myScrapBooths',
+    apiFn: scrapBoothsApiFn,
+    dataKey: 'result',
+    transform: transformBoothData,
+    limit: 6,
+    filters,
+  });
+  return { ...rest, booths, totalCount };
+};
+
+export const useMyScrapShows = (filters = {}) => {
+  const {
+    items: shows,
+    totalCount,
+    ...rest
+  } = useInfiniteList({
+    queryKey: 'myScrapShows',
+    apiFn: scrapShowsApiFn,
+    dataKey: 'result',
+    transform: transformShowData,
+    limit: 6,
+    filters,
+  });
+  return { ...rest, shows, totalCount };
+};

--- a/src/hooks/useShows.js
+++ b/src/hooks/useShows.js
@@ -2,15 +2,12 @@
  * 공연 목록 조회 hook (무한 스크롤)
  */
 
-import { useMemo } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
 import { ShowAPI } from '@/apis';
 import { SHOW_CATEGORY } from '@/constants/category';
 import { BOOTH_LOCATION } from '@/constants/building';
 import { FESTIVAL_DAYS } from '@/constants/day';
 import { getLabel, padNumber } from '@/utils/labelHelper';
-
-const LIMIT = 8; // 한 페이지당 10개씩 로드 (화면에는 5개 보임)
+import { useInfiniteList } from '@/hooks/useInfiniteList';
 
 /**
  * 공연 목록 조회 (무한 스크롤)
@@ -18,89 +15,15 @@ const LIMIT = 8; // 한 페이지당 10개씩 로드 (화면에는 5개 보임)
  * @returns {Object} useInfiniteQuery 결과 + 변환된 shows, totalCount
  */
 export const useShows = (filters = {}) => {
-  const queryResult = useInfiniteQuery({
-    queryKey: ['shows', filters],
-    queryFn: async ({ pageParam = 0 }) => {
-      const params = buildQueryParams(filters, pageParam);
-      const data = await ShowAPI.getShows(params);
-
-      // API 응답 데이터를 변환하여 반환
-      return {
-        ...data,
-        result: data.result.map(transformShowData),
-      };
-    },
-    getNextPageParam: (lastPage, allPages) => {
-      if (lastPage.next) {
-        return allPages.length * LIMIT;
-      }
-      return undefined;
-    },
-    initialPageParam: 0,
-    staleTime: 1000 * 60 * 5, // 5분
+  const { items: shows, totalCount, ...rest } = useInfiniteList({
+    queryKey: 'shows',
+    apiFn: ShowAPI.getShows,
+    dataKey: 'result',
+    transform: transformShowData,
+    limit: 8,
+    filters,
   });
-
-  // 모든 페이지의 공연 데이터 합치기
-  const shows = useMemo(() => {
-    return queryResult.data?.pages.flatMap((page) => page.result) || [];
-  }, [queryResult.data]);
-
-  // 전체 공연 개수
-  const totalCount = useMemo(() => {
-    return queryResult.data?.pages[0]?.count || 0;
-  }, [queryResult.data]);
-
-  return {
-    ...queryResult,
-    shows, // ✨ 변환된 공연 배열
-    totalCount, // ✨ 전체 개수
-  };
-};
-
-/**
- * 필터 객체를 쿼리 파라미터로 변환
- */
-const buildQueryParams = (filters, offset) => {
-  const params = {
-    limit: LIMIT,
-    offset,
-  };
-
-  // 종료 제외 로직 (부스와 동일)
-  // - 체크박스 OFF (excludeEnded=false, 기본): is_ongoing=false 전송 → 종료 포함
-  // - 체크박스 ON (excludeEnded=true): is_ongoing=true 전송 → 종료 제외
-  if (filters.excludeEnded) {
-    params.is_ongoing = true; // 운영 중인 것만
-  } else {
-    params.is_ongoing = false; // 모두 포함
-  }
-
-  // 카테고리 (배열)
-  if (filters.category?.length > 0) {
-    params.category = filters.category;
-  }
-
-  // 위치 (location → building)
-  if (filters.location?.length > 0) {
-    params.building = filters.location;
-  }
-
-  // 주관 (host)
-  if (filters.host?.length > 0) {
-    params.host = filters.host;
-  }
-
-  // 요일 (day → date, YYYY-MM-DD 형식)
-  if (filters.day?.length > 0) {
-    params.date = filters.day;
-  }
-
-  // 정렬 (sort → sorting)
-  if (filters.sort) {
-    params.sorting = filters.sort;
-  }
-
-  return params;
+  return { ...rest, shows, totalCount };
 };
 
 /**
@@ -152,7 +75,7 @@ export const getTimesText = (times) => {
  * @param {Object} show - 원본 공연 데이터
  * @returns {Object} - 변환된 공연 데이터 (categoryText, daysText, timesText, locationText, badgeState 추가)
  */
-const transformShowData = (show) => {
+export const transformShowData = (show) => {
   const { category, schedule = [], location, is_ongoing, is_scraped, scraps_count } = show;
 
   // 카테고리 한글 변환

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -227,7 +227,7 @@ const MyPage = () => {
           >
             축제준비위원회에게 문의하기
           </Button>
-          <Button variant="underline-gray" onClick={handleWithdrawalClick}>
+          <Button variant="underline-lightgray" onClick={handleWithdrawalClick}>
             회원 탈퇴하기
           </Button>
         </div>

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -52,7 +52,9 @@ const MyPage = () => {
 
   const handleLogoutClick = () => {
     openAlert({
-      variant: 'logout',
+      variant: 'confirm',
+      title: '로그아웃하시겠어요?',
+      text: '언제든지 다시 로그인하실 수 있어요.',
       onConfirm: async () => {
         try {
           await AuthAPI.logout();
@@ -62,6 +64,26 @@ const MyPage = () => {
         } finally {
           closeAlert();
         }
+      },
+      onCancel: closeAlert,
+    });
+  };
+
+  const handleWithdrawalClick = () => {
+    openAlert({
+      variant: 'confirm',
+      title: '탈퇴하시겠어요?',
+      text: (
+        <>
+          탈퇴는 이화여대 멋쟁이사자처럼
+          <br />
+          카카오톡 채널에서 도와드리고 있어요.
+        </>
+      ),
+      confirmLabel: '채널 바로가기',
+      onConfirm: () => {
+        window.open('https://pf.kakao.com/_htxexfd', '_blank');
+        closeAlert();
       },
       onCancel: closeAlert,
     });
@@ -194,7 +216,7 @@ const MyPage = () => {
           </button>
         </div>
         {/* 축준위 문의 버튼 */}
-        <div className="mt-28 mb-14.5 flex justify-center">
+        <div className="mt-28 mb-6 flex flex-col items-center gap-6">
           <Button
             variant="bg-white"
             circle
@@ -204,6 +226,9 @@ const MyPage = () => {
             onClick={goFestivalKakaotalk}
           >
             축제준비위원회에게 문의하기
+          </Button>
+          <Button variant="underline-gray" onClick={handleWithdrawalClick}>
+            회원 탈퇴하기
           </Button>
         </div>
       </div>

--- a/src/pages/my/ScrapBooth.jsx
+++ b/src/pages/my/ScrapBooth.jsx
@@ -1,0 +1,101 @@
+/**
+ * 스크랩 부스 목록
+ */
+
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import useFilterStore from '@/store/useFilterStore';
+import { useMyScrapBooths } from '@/hooks/useMyScrap';
+
+import FilterBar from '@/components/FilterBar';
+import Checkbox from '@/components/Checkbox';
+import DropDown from '@/components/DropDown';
+import BoothCard from '@/components/Card/BoothCard';
+
+const ScrapBooth = () => {
+  const navigate = useNavigate();
+
+  const scrapBoothFilters = useFilterStore((s) => s.filters.scrap_booth);
+  const setFilter = useFilterStore((s) => s.setFilter);
+
+  const { booths, totalCount, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useMyScrapBooths(scrapBoothFilters);
+
+  const handleBoothExcludeEndedChange = (value) => {
+    setFilter('scrap_booth', 'excludeEnded', value);
+  };
+
+  const hasActiveFilters =
+    scrapBoothFilters.category.length > 0 ||
+    scrapBoothFilters.location.length > 0 ||
+    scrapBoothFilters.host.length > 0 ||
+    scrapBoothFilters.day.length > 0 ||
+    scrapBoothFilters.sort !== null ||
+    scrapBoothFilters.excludeEnded;
+
+  // 윈도우 스크롤 기반 무한 스크롤
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+      if ((scrollTop + clientHeight) / scrollHeight > 0.8 && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return (
+    <>
+      <div className="flex flex-col gap-4">
+        <FilterBar type="scrap_booth" />
+        <div className="flex items-center justify-between text-sm font-normal text-zinc-500">
+          총 {totalCount}개
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1">
+              종료 제외
+              <Checkbox
+                isSelected={scrapBoothFilters.excludeEnded}
+                onChange={handleBoothExcludeEndedChange}
+              />
+            </div>
+            <DropDown type="scrap_booth" />
+          </div>
+        </div>
+
+        {/* 로딩 */}
+        {isLoading && <div className="py-24 text-center text-zinc-300">로딩 중...</div>}
+
+        {/* 에러 */}
+        {isError && (
+          <div className="py-24 text-center text-zinc-300">데이터를 불러오는데 실패했습니다.</div>
+        )}
+
+        {/* 빈 상태 */}
+        {!isLoading && !isError && booths.length === 0 && (
+          <div className="flex justify-center pt-20 text-center text-base font-normal text-zinc-300">
+            {hasActiveFilters ? '검색 결과가 없어요.' : '아직 스크랩한 부스가 없어요.'}
+          </div>
+        )}
+
+        {!isLoading &&
+          !isError &&
+          booths.map((booth) => (
+            <BoothCard
+              key={booth.id}
+              booth={booth}
+              onClick={() => navigate(`/map/booths/${booth.id}`)}
+            />
+          ))}
+
+        {/* 다음 페이지 로딩 */}
+        {isFetchingNextPage && (
+          <div className="py-4 text-center text-sm text-zinc-300">더 불러오는 중...</div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ScrapBooth;

--- a/src/pages/my/ScrapPage.jsx
+++ b/src/pages/my/ScrapPage.jsx
@@ -1,3 +1,28 @@
 /**
  * 스크랩 페이지
  */
+
+import { useState } from 'react';
+
+import Header from '@/components/Header';
+import Tab from '@/components/Tab';
+import ScrapBooth from '@/pages/my/ScrapBooth';
+import ScrapShow from '@/pages/my/ScrapShow';
+
+const totalCount = 0;
+
+const ScrapPage = () => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  return (
+    <>
+      <Header left="back" center="title" centerTitle="스크랩북" right="search" />
+      <div className="mt-18 flex flex-col gap-4 px-5 pt-5">
+        <Tab tabs={['부스', '공연']} activeIndex={activeIndex} onChange={setActiveIndex} />
+        {activeIndex === 0 ? <ScrapBooth /> : <ScrapShow />}
+      </div>
+    </>
+  );
+};
+
+export default ScrapPage;

--- a/src/pages/my/ScrapShow.jsx
+++ b/src/pages/my/ScrapShow.jsx
@@ -1,0 +1,96 @@
+/**
+ * 스크랩 공연 목록
+ */
+
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import useFilterStore from '@/store/useFilterStore';
+import { useMyScrapShows } from '@/hooks/useMyScrap';
+
+import FilterBar from '@/components/FilterBar';
+import Checkbox from '@/components/Checkbox';
+import DropDown from '@/components/DropDown';
+import ShowCard from '@/components/Card/ShowCard';
+
+const ScrapShow = () => {
+  const navigate = useNavigate();
+
+  const scrapShowFilters = useFilterStore((s) => s.filters.scrap_show);
+  const setFilter = useFilterStore((s) => s.setFilter);
+
+  const { shows, totalCount, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useMyScrapShows(scrapShowFilters);
+
+  const handleShowExcludeEndedChange = (value) => {
+    setFilter('scrap_show', 'excludeEnded', value);
+  };
+
+  const hasActiveFilters =
+    scrapShowFilters.category.length > 0 ||
+    scrapShowFilters.host.length > 0 ||
+    scrapShowFilters.day.length > 0 ||
+    scrapShowFilters.sort !== null ||
+    scrapShowFilters.excludeEnded;
+
+  // 윈도우 스크롤 기반 무한 스크롤
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+      if ((scrollTop + clientHeight) / scrollHeight > 0.8 && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return (
+    <>
+      <div className="flex flex-col gap-4">
+        <FilterBar type="scrap_show" />
+        <div className="flex items-center justify-between text-sm font-normal text-zinc-500">
+          총 {totalCount}개
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1">
+              종료 제외
+              <Checkbox
+                isSelected={scrapShowFilters.excludeEnded}
+                onChange={handleShowExcludeEndedChange}
+              />
+            </div>
+            <DropDown type="scrap_show" />
+          </div>
+        </div>
+
+        {/* 로딩 */}
+        {isLoading && <div className="py-24 text-center text-zinc-300">로딩 중...</div>}
+
+        {/* 에러 */}
+        {isError && (
+          <div className="py-24 text-center text-zinc-300">데이터를 불러오는데 실패했습니다.</div>
+        )}
+
+        {/* 빈 상태 */}
+        {!isLoading && !isError && shows.length === 0 && (
+          <div className="flex justify-center pt-20 text-center text-base font-normal text-zinc-300">
+            {hasActiveFilters ? '검색 결과가 없어요.' : '아직 스크랩한 공연이 없어요.'}
+          </div>
+        )}
+
+        {!isLoading &&
+          !isError &&
+          shows.map((show) => (
+            <ShowCard key={show.id} show={show} onClick={() => navigate(`/map/shows/${show.id}`)} />
+          ))}
+
+        {/* 다음 페이지 로딩 */}
+        {isFetchingNextPage && (
+          <div className="py-4 text-center text-sm text-zinc-300">더 불러오는 중...</div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ScrapShow;


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->

- close #122

<br />

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

### Summary

- **ScrapPage 구현**: 스크랩 부스/공연 목록 조회, 필터링, 무한 스크롤 기능 추가
- **useInfiniteList 공용 훅 추가**: `useBooths`, `useShows`, `useMyScrap`의 중복 코드(`buildQueryParams`, `useInfiniteQuery` 보일러플레이트) 추상화
- **ScrapButton 낙관적 업데이트 개선**: 스크랩 취소 시 목록 캐시에서 즉시 제거, 실패 시 롤백 처리
- **Alert 컴포넌트 개선**: `logout` variant 제거 → `confirm` variant 추가, `confirmLabel` prop으로 버튼 문구 자유롭게 설정 가능
- **MyPage 로그아웃/탈퇴 확인 알림 추가**

### Changes

#### ✨ New
- `src/pages/my/ScrapPage.jsx` — 스크랩북 페이지 (부스/공연 탭)
- `src/pages/my/ScrapBooth.jsx` — 스크랩 부스 목록 (필터, 무한 스크롤, 빈 상태 분기)
- `src/pages/my/ScrapShow.jsx` — 스크랩 공연 목록 (필터, 무한 스크롤, 빈 상태 분기)
- `src/hooks/useInfiniteList.js` — 무한 스크롤 공용 훅 + `buildQueryParams` 공통화
- `src/hooks/useMyScrap.js` — `useMyScrapBooths`, `useMyScrapShows` (스크랩 API 응답 정규화 포함)

#### ♻️ Refactor
- `useBooths`, `useShows` — `useInfiniteList` 래퍼로 간소화 (~60줄 → ~10줄)
- `ScrapButton` — `onMutate`에서 스크랩 취소 시 `myScrapBooths`/`myScrapShows` 캐시 즉시 업데이트, `onError`에서 롤백
- `Alert` — `variant: logout` 제거, `variant: confirm` 추가, `confirmLabel` prop 추가
<br />

## 📸 UI 작업 시

<!-- 이미지 or 영상 or 프리뷰 링크 첨부 -->
<!-- 프리뷰 링크에 해당 페이지의 라우트 경로까지 포함하여 작성 -->
https://14th-ewha-festival-front-dcwneudo8-yxpjseos-projects.vercel.app/my/scrap

<br />

## 💬 To. Reviewer (선택)

<br />

## ✅ 체크 리스트

- [ ] main 브랜치 pull 완료
- [x] Reviewers 설정
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정
