### PR TITLE
검색 api 연결

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,7 +58,6 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/kakao-redirect" element={<KakaoRedirect />} />
           <Route path="credit" element={<CreditPage />} />
-          <Route path="search" element={<SearchPage />} />
 
           {/* 마이 */}
           <Route path="my" element={<MyPage />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -14,7 +14,7 @@
  * @param {Boolean} props.isSheet - 뒤로가기 버튼 클릭 핸들러 결정용
  */
 
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import SearchBar from '@/components/SearchBar';
 import useBottomsheetStore from '@/store/useBottomsheetStore';
 
@@ -29,6 +29,7 @@ const Header = ({
   isSheet = false,
 }) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const setSheetSize = useBottomsheetStore((s) => s.setSheetSize);
 
   // 배경 스타일
@@ -42,7 +43,7 @@ const Header = ({
   const handleBack = () => {
     if (isSheet) {
       setSheetSize('medium');
-    } else if (window.history.length > 1) {
+    } else if (location.key !== 'default') {
       navigate(-1);
     } else {
       navigate('/');

--- a/src/components/ScrapButton.jsx
+++ b/src/components/ScrapButton.jsx
@@ -88,6 +88,7 @@ const ScrapButton = ({
     onSuccess: (_data, _variables, context) => {
       queryClient.invalidateQueries({ queryKey: listQueryKey });
       queryClient.invalidateQueries({ queryKey: scrapQueryKey });
+      queryClient.invalidateQueries({ queryKey: ['myProfile'] });
 
       if (onToggle) onToggle(!context.previousScrapped);
     },

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -3,7 +3,7 @@
  */
 
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Button from '@/components/Button';
 import useSearchStore from '@/store/useSearchStore';
 import useBottomsheetStore from '@/store/useBottomsheetStore';
@@ -11,6 +11,7 @@ import { useSearch } from '@/hooks';
 
 const SearchBar = ({ isMap = false }) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const setSheetSize = useBottomsheetStore((s) => s.setSheetSize);
   const { searchQuery, setSearchQuery, clearSearchQuery, isFocused, setIsFocused } =
     useSearchStore();
@@ -18,16 +19,18 @@ const SearchBar = ({ isMap = false }) => {
 
   const handleBack = () => {
     clearSearchQuery();
+    setIsFocused(false);
     setSheetSize('medium');
-    navigate('/map/booths');
-    // 지도 초기화
+    if (location.key !== 'default') {
+      navigate(-1);
+    } else {
+      navigate('/map/booths');
+    }
   };
 
   const handleClear = () => {
     clearSearchQuery();
     setSheetSize('medium');
-    navigate('/map/booths');
-    // 지도 유지
   };
 
   const handleSearch = () => {
@@ -42,7 +45,9 @@ const SearchBar = ({ isMap = false }) => {
 
   const handleInputClick = () => {
     setIsFocused(true);
-    navigate('/search');
+    if (location.pathname !== '/search') {
+      navigate('/search');
+    }
   };
 
   return (
@@ -53,6 +58,7 @@ const SearchBar = ({ isMap = false }) => {
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
         onKeyDown={handleKeyDown}
+        autoFocus={location.pathname === '/search'}
         onClick={handleInputClick}
         className={`h-12 w-full rounded-full transition-all duration-100 ${isMap ? 'shadow-down-lg bg-white' : 'bg-zinc-100'} py-3 text-base font-normal text-zinc-800 placeholder:text-zinc-300 focus:outline-none ${
           isFocused || searchQuery ? 'px-12.5 ' : 'px-5'
@@ -71,6 +77,7 @@ const SearchBar = ({ isMap = false }) => {
         leftIcon="/icons/icon-chevronleft.svg"
         variant="text-black"
         size="md"
+        onMouseDown={(e) => e.preventDefault()}
         onClick={handleBack}
         className={`absolute top-1/2 left-1 -translate-y-1/2 transition-opacity duration-100 ${
           isFocused || searchQuery ? 'opacity-100' : 'pointer-events-none opacity-0'

--- a/src/features/booth/BoothListSheet.jsx
+++ b/src/features/booth/BoothListSheet.jsx
@@ -8,7 +8,8 @@ import { useNavigate, useMatch } from 'react-router-dom';
 import BottomsheetDrag from '@/components/BottomsheetDrag';
 import useBottomsheetStore from '@/store/useBottomsheetStore';
 import useFilterStore from '@/store/useFilterStore';
-import { useBooths, useInfiniteScroll } from '@/hooks';
+import { useBooths, useInfiniteScroll, useSearchResults } from '@/hooks';
+import useSearchStore from '@/store/useSearchStore';
 
 import Header from '@/components/Header';
 import Tab from '@/components/Tab';
@@ -27,9 +28,21 @@ const BoothListSheet = () => {
   const matchBooths = useMatch('/map/booths');
   const activeTabIndex = matchBooths ? 0 : 1;
 
-  // TanStack Query로 부스 데이터 가져오기
-  const { booths, totalCount, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useBooths(boothFilters);
+  const searchQuery = useSearchStore((s) => s.searchQuery);
+  const isSearchMode = !!searchQuery;
+
+  const boothsQuery = useBooths(boothFilters);
+  const searchResultsQuery = useSearchResults(searchQuery);
+
+  const booths = isSearchMode ? searchResultsQuery.booths : boothsQuery.booths;
+  const totalCount = isSearchMode ? searchResultsQuery.boothCount : boothsQuery.totalCount;
+  const isLoading = isSearchMode ? searchResultsQuery.isLoading : boothsQuery.isLoading;
+  const isError = isSearchMode ? searchResultsQuery.isError : boothsQuery.isError;
+  const fetchNextPage = isSearchMode ? searchResultsQuery.fetchNextPage : boothsQuery.fetchNextPage;
+  const hasNextPage = isSearchMode ? searchResultsQuery.hasNextPage : boothsQuery.hasNextPage;
+  const isFetchingNextPage = isSearchMode
+    ? searchResultsQuery.isFetchingNextPage
+    : boothsQuery.isFetchingNextPage;
 
   const handleTabChange = (index) => {
     navigate(index === 0 ? '/map/booths' : '/map/shows');

--- a/src/features/booth/BoothListSheet.jsx
+++ b/src/features/booth/BoothListSheet.jsx
@@ -17,6 +17,7 @@ import FilterBar from '@/components/FilterBar';
 import Checkbox from '@/components/Checkbox';
 import DropDown from '@/components/DropDown';
 import BoothCard from '@/components/Card/BoothCard';
+import LoadingSpinner from '@/components/LoadingSpinner';
 
 const BoothListSheet = () => {
   const isFull = useBottomsheetStore((s) => s.isFull());
@@ -72,10 +73,10 @@ const BoothListSheet = () => {
       </div>
       <BottomsheetDrag scrollContainerRef={scrollContainerRef}>
         {isFull && <Header center="search" />}
-        <div className="flex flex-col gap-4 p-5">
+        <div className="flex h-full flex-col gap-4 p-5">
           <Tab tabs={['부스', '공연']} activeIndex={activeTabIndex} onChange={handleTabChange} />
           <FilterBar type="booth" />
-          <div className="flex flex-col">
+          <div className="flex min-h-0 flex-1 flex-col">
             <div className="flex items-center justify-between text-sm font-normal text-zinc-500">
               총 {totalCount}개
               <div className="flex items-center gap-2">
@@ -91,7 +92,11 @@ const BoothListSheet = () => {
             </div>
 
             {/* 로딩 */}
-            {isLoading && <div className="py-24 text-center text-zinc-300">로딩 중...</div>}
+            {isLoading && (
+              <div className="flex h-full items-center justify-center">
+                <LoadingSpinner />
+              </div>
+            )}
 
             {/* 에러 */}
             {isError && (

--- a/src/features/show/ShowDetailSheet.jsx
+++ b/src/features/show/ShowDetailSheet.jsx
@@ -103,174 +103,181 @@ const ShowDetailSheet = () => {
           </>
         )}
 
-        {!isLoading && <div className="flex w-full flex-col items-center gap-9 pt-5">
-          {/* 부스 설명 */}
-          <div className="flex w-full flex-col gap-6 self-stretch px-5">
-            <div className="flex w-full flex-col items-start gap-2 self-stretch">
-              <div className="flex w-full items-center justify-between self-stretch">
-                <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
-                  {show.name || '공연명'}
-                </h2>
-                <ScrapButton id={id} type="show" initialScrapped={show.is_scrapped} count={show.scraps_count} />
-              </div>
-
-              {(categoryText || show.is_ongoing !== undefined) && (
-                <div className="flex items-center gap-1">
-                  {categoryText && (
-                    <p className="text-sm leading-5 font-normal tracking-normal text-zinc-500">
-                      {categoryText}
-                    </p>
-                  )}
-
-                  {show.is_ongoing !== undefined && (
-                    <>
-                      {categoryText && <img src="/icons/icon-eclipse-gray.svg" />}
-                      <Badge state={getShowState(show.is_ongoing)} size="md" />
-                    </>
-                  )}
+        {!isLoading && (
+          <div className="flex w-full flex-col items-center gap-9 pt-5">
+            {/* 부스 설명 */}
+            <div className="flex w-full flex-col gap-6 self-stretch px-5">
+              <div className="flex w-full flex-col items-start gap-2 self-stretch">
+                <div className="flex w-full items-center justify-between self-stretch">
+                  <h2 className="text-2xl leading-8 font-semibold tracking-normal text-zinc-800">
+                    {show.name || '공연명'}
+                  </h2>
+                  <ScrapButton
+                    id={id}
+                    type="show"
+                    initialScrapped={show.is_scrapped}
+                    count={show.scraps_count}
+                  />
                 </div>
-              )}
 
-              {show.description && (
-                <p className="line-clamp-2 max-h-10 self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
-                  {show.description}
-                </p>
-              )}
-            </div>
+                {(categoryText || show.is_ongoing !== undefined) && (
+                  <div className="flex items-center gap-1">
+                    {categoryText && (
+                      <p className="text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                        {categoryText}
+                      </p>
+                    )}
 
-            <Divider />
-
-            <div className="flex-start flex flex-col gap-4 self-stretch">
-              {/* 시간 */}
-              <div className="flex items-start gap-4">
-                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
-                  시간
-                </h3>
-                <div className="flex flex-col items-start gap-0.5">
-                  {scheduleText.length > 0 ? (
-                    scheduleText.map((t, i) => (
-                      <h3
-                        key={i}
-                        className="text-sm leading-5 font-normal tracking-normal text-zinc-800"
-                      >
-                        {t}
-                      </h3>
-                    ))
-                  ) : (
-                    <h3 className="text-sm leading-5 font-normal tracking-normal text-zinc-800">
-                      -
-                    </h3>
-                  )}
-                </div>
-              </div>
-
-              {/* 위치 */}
-              <div className="flex items-start gap-4">
-                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
-                  위치
-                </h3>
-                <div className="flex flex-col items-start gap-1.5">
-                  <div className="flex items-center gap-1.5">
-                    <button
-                      className={`text-sm leading-5 font-medium tracking-normal text-zinc-800 ${
-                        locationName
-                          ? 'underline decoration-solid underline-offset-2'
-                          : 'cursor-default'
-                      }`}
-                    >
-                      {locationName || '-'}
-                    </button>
-
-                    {show.roadview && (
+                    {show.is_ongoing !== undefined && (
                       <>
-                        <img src="/icons/icon-eclipse-gray.svg" />
-                        <button
-                          className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
-                          onClick={() => {
-                            setSelectedImage(show.roadview);
-                            setShowModal(true);
-                          }}
-                        >
-                          로드뷰
-                        </button>
+                        {categoryText && <img src="/icons/icon-eclipse-gray.svg" />}
+                        <Badge state={getShowState(show.is_ongoing)} size="md" />
                       </>
                     )}
                   </div>
+                )}
 
-                  {show.location_description && (
-                    <p className="text-xs leading-4 font-normal tracking-normal text-zinc-500">
-                      {show.location_description}
-                    </p>
-                  )}
-                </div>
+                {show.description && (
+                  <p className="line-clamp-2 max-h-10 self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                    {show.description}
+                  </p>
+                )}
               </div>
 
-              {/* SNS */}
-              <div className="flex items-start gap-4">
-                <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
-                  SNS
-                </h3>
-                <div className="flex items-center gap-2.5">
-                  {snsLinks.instagram && (
-                    <img
-                      src="/icons/logo-instagramcolor.svg"
-                      className="h-7 w-7 cursor-pointer rounded-md"
-                      onClick={() => window.open(snsLinks.instagram, '_blank')}
-                    />
-                  )}
+              <Divider />
 
-                  {snsLinks.kakaotalk && (
-                    <img
-                      src="/icons/logo-kakaotalkcolor.svg"
-                      className="h-7 w-7 cursor-pointer rounded-md"
-                      onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
-                    />
-                  )}
+              <div className="flex-start flex flex-col gap-4 self-stretch">
+                {/* 시간 */}
+                <div className="flex items-start gap-4">
+                  <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                    시간
+                  </h3>
+                  <div className="flex flex-col items-start gap-0.5">
+                    {scheduleText.length > 0 ? (
+                      scheduleText.map((t, i) => (
+                        <h3
+                          key={i}
+                          className="text-sm leading-5 font-normal tracking-normal text-zinc-800"
+                        >
+                          {t}
+                        </h3>
+                      ))
+                    ) : (
+                      <h3 className="text-sm leading-5 font-normal tracking-normal text-zinc-800">
+                        -
+                      </h3>
+                    )}
+                  </div>
+                </div>
 
-                  {!snsLinks.instagram && !snsLinks.kakaotalk && (
-                    <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
-                  )}
+                {/* 위치 */}
+                <div className="flex items-start gap-4">
+                  <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                    위치
+                  </h3>
+                  <div className="flex flex-col items-start gap-1.5">
+                    <div className="flex items-center gap-1.5">
+                      <button
+                        className={`text-sm leading-5 font-medium tracking-normal text-zinc-800 ${
+                          locationName
+                            ? 'underline decoration-solid underline-offset-2'
+                            : 'cursor-default'
+                        }`}
+                      >
+                        {locationName || '-'}
+                      </button>
+
+                      {show.roadview && (
+                        <>
+                          <img src="/icons/icon-eclipse-gray.svg" />
+                          <button
+                            className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
+                            onClick={() => {
+                              setSelectedImage(show.roadview);
+                              setShowModal(true);
+                            }}
+                          >
+                            로드뷰
+                          </button>
+                        </>
+                      )}
+                    </div>
+
+                    {show.location_description && (
+                      <p className="text-xs leading-4 font-normal tracking-normal text-zinc-500">
+                        {show.location_description}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* SNS */}
+                <div className="flex items-start gap-4">
+                  <h3 className="w-7 text-center text-sm leading-5 font-semibold tracking-normal text-zinc-500">
+                    SNS
+                  </h3>
+                  <div className="flex items-center gap-2.5">
+                    {snsLinks.instagram && (
+                      <img
+                        src="/icons/logo-instagramcolor.svg"
+                        className="h-7 w-7 cursor-pointer rounded-md"
+                        onClick={() => window.open(snsLinks.instagram, '_blank')}
+                      />
+                    )}
+
+                    {snsLinks.kakaotalk && (
+                      <img
+                        src="/icons/logo-kakaotalkcolor.svg"
+                        className="h-7 w-7 cursor-pointer rounded-md"
+                        onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
+                      />
+                    )}
+
+                    {!snsLinks.instagram && !snsLinks.kakaotalk && (
+                      <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          {/* 공지 */}
-          <div className="w-full px-5">
-            {show.latest_notice ? (
-              <NoticeCard
-                title={show.latest_notice.title}
-                onClick={goNoticePage}
-                style={{ cursor: 'pointer' }}
-              />
-            ) : (
-              <NoticeCard title="등록된 공지가 없어요." />
-            )}
-          </div>
-
-          {/* 리스트 */}
-          <div className="flex w-full flex-col items-center gap-2 self-stretch px-5">
-            <Tab
-              variant="underline"
-              tabs={['세트리스트']}
-              activeIndex={activeTab}
-              onChange={(index) => setActiveTab(index)}
-            />
-            <div className="flex w-full flex-col items-start self-stretch">
-              {activeTab === 0 && (
-                <div className="flex w-full flex-col gap-2 pb-36">
-                  {show.setlist && show.setlist.length > 0 ? (
-                    show.setlist.map((item) => <SetlistCard key={item.id} title={item.name} />)
-                  ) : (
-                    <div className="flex w-full items-center justify-center self-stretch py-20 text-center text-base leading-6 font-normal tracking-normal text-zinc-300">
-                      등록된 내용이 없어요.
-                    </div>
-                  )}
-                </div>
+            {/* 공지 */}
+            <div className="w-full px-5">
+              {show.latest_notice ? (
+                <NoticeCard
+                  title={show.latest_notice.title}
+                  onClick={goNoticePage}
+                  style={{ cursor: 'pointer' }}
+                />
+              ) : (
+                <NoticeCard title="등록된 공지가 없어요." />
               )}
             </div>
+
+            {/* 리스트 */}
+            <div className="flex w-full flex-col items-center gap-2 self-stretch px-5">
+              <Tab
+                variant="underline"
+                tabs={['세트리스트']}
+                activeIndex={activeTab}
+                onChange={(index) => setActiveTab(index)}
+              />
+              <div className="flex w-full flex-col items-start self-stretch">
+                {activeTab === 0 && (
+                  <div className="flex w-full flex-col gap-2 pb-36">
+                    {show.setlist && show.setlist.length > 0 ? (
+                      show.setlist.map((item) => <SetlistCard key={item.id} title={item.name} />)
+                    ) : (
+                      <div className="flex w-full items-center justify-center self-stretch py-20 text-center text-base leading-6 font-normal tracking-normal text-zinc-300">
+                        등록된 내용이 없어요.
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
-        </div>}
+        )}
 
         {showModal && <ImageModal image={selectedImage} onClose={() => setShowModal(false)} />}
       </BottomsheetDrag>

--- a/src/features/show/ShowListSheet.jsx
+++ b/src/features/show/ShowListSheet.jsx
@@ -8,7 +8,8 @@ import { useNavigate, useMatch } from 'react-router-dom';
 import BottomsheetDrag from '@/components/BottomsheetDrag';
 import useBottomsheetStore from '@/store/useBottomsheetStore';
 import useFilterStore from '@/store/useFilterStore';
-import { useShows, useInfiniteScroll } from '@/hooks';
+import { useShows, useInfiniteScroll, useSearchResults } from '@/hooks';
+import useSearchStore from '@/store/useSearchStore';
 
 import Header from '@/components/Header';
 import Tab from '@/components/Tab';
@@ -27,9 +28,21 @@ const ShowListSheet = () => {
   const matchShows = useMatch('/map/shows');
   const activeTabIndex = matchShows ? 1 : 0;
 
-  // TanStack Query로 공연 데이터 가져오기
-  const { shows, totalCount, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useShows(showFilters);
+  const searchQuery = useSearchStore((s) => s.searchQuery);
+  const isSearchMode = !!searchQuery;
+
+  const showsQuery = useShows(showFilters);
+  const searchResultsQuery = useSearchResults(searchQuery);
+
+  const shows = isSearchMode ? searchResultsQuery.shows : showsQuery.shows;
+  const totalCount = isSearchMode ? searchResultsQuery.showCount : showsQuery.totalCount;
+  const isLoading = isSearchMode ? searchResultsQuery.isLoading : showsQuery.isLoading;
+  const isError = isSearchMode ? searchResultsQuery.isError : showsQuery.isError;
+  const fetchNextPage = isSearchMode ? searchResultsQuery.fetchNextPage : showsQuery.fetchNextPage;
+  const hasNextPage = isSearchMode ? searchResultsQuery.hasNextPage : showsQuery.hasNextPage;
+  const isFetchingNextPage = isSearchMode
+    ? searchResultsQuery.isFetchingNextPage
+    : showsQuery.isFetchingNextPage;
 
   const handleTabChange = (index) => {
     navigate(index === 0 ? '/map/booths' : '/map/shows');

--- a/src/features/show/ShowListSheet.jsx
+++ b/src/features/show/ShowListSheet.jsx
@@ -17,6 +17,7 @@ import FilterBar from '@/components/FilterBar';
 import Checkbox from '@/components/Checkbox';
 import DropDown from '@/components/DropDown';
 import ShowCard from '@/components/Card/ShowCard';
+import LoadingSpinner from '@/components/LoadingSpinner';
 
 const ShowListSheet = () => {
   const isFull = useBottomsheetStore((s) => s.isFull());
@@ -72,10 +73,10 @@ const ShowListSheet = () => {
       </div>
       <BottomsheetDrag scrollContainerRef={scrollContainerRef}>
         {isFull && <Header center="search" />}
-        <div className="flex flex-col gap-4 p-5">
+        <div className="flex h-full flex-col gap-4 p-5">
           <Tab tabs={['부스', '공연']} activeIndex={activeTabIndex} onChange={handleTabChange} />
           <FilterBar type="show" />
-          <div className="flex flex-col">
+          <div className="flex min-h-0 flex-1 flex-col">
             <div className="flex items-center justify-between text-sm font-normal text-zinc-500">
               총 {totalCount}개
               <div className="flex items-center gap-2">
@@ -91,7 +92,11 @@ const ShowListSheet = () => {
             </div>
 
             {/* 로딩 */}
-            {isLoading && <div className="py-24 text-center text-zinc-300">로딩 중...</div>}
+            {isLoading && (
+              <div className="flex h-full items-center justify-center">
+                <LoadingSpinner />
+              </div>
+            )}
 
             {/* 에러 */}
             {isError && (

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -7,3 +7,4 @@ export { useBooths } from './useBooths.js';
 export { useShows } from './useShows.js';
 export { useInfiniteScroll } from './useInfiniteScroll.js';
 export { useInfiniteList, buildQueryParams } from './useInfiniteList.js';
+export { usePopularKeywords } from './usePopularKeywords.js';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -8,3 +8,4 @@ export { useShows } from './useShows.js';
 export { useInfiniteScroll } from './useInfiniteScroll.js';
 export { useInfiniteList, buildQueryParams } from './useInfiniteList.js';
 export { usePopularKeywords } from './usePopularKeywords.js';
+export { useSearchResults } from './useSearchResults.js';

--- a/src/hooks/usePopularKeywords.js
+++ b/src/hooks/usePopularKeywords.js
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { SearchAPI } from '@/apis';
+
+export const usePopularKeywords = () => {
+  return useQuery({
+    queryKey: ['popularKeywords'],
+    queryFn: SearchAPI.getPopularKeywords,
+    staleTime: 1000 * 60 * 30, // 30분
+  });
+};

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -21,10 +21,7 @@ export const useSearch = () => {
     setSearchQuery(trimmed);
     addRecentSearch(trimmed);
 
-    // 검색 결과 페이지로 이동
-    console.log('검색 실행:', trimmed);
-    // TODO: 검색 결과 페이지 구현 후 주석 해제
-    // navigate(`/search-result?q=${encodeURIComponent(trimmed)}`);
+    navigate('/map/booths');
   };
 
   return { executeSearch };

--- a/src/hooks/useSearchResults.js
+++ b/src/hooks/useSearchResults.js
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { SearchAPI } from '@/apis';
+import { transformBoothData } from '@/hooks/useBooths';
+import { transformShowData } from '@/hooks/useShows';
+
+const LIMIT = 10;
+
+export const useSearchResults = (query) => {
+  const queryResult = useInfiniteQuery({
+    queryKey: ['searchResults', query],
+    queryFn: async ({ pageParam = 0 }) => {
+      const data = await SearchAPI.searchContents({ q: query, offset: pageParam });
+      return {
+        booths: {
+          ...data.booths,
+          search_result: (data.booths?.search_result ?? []).map(transformBoothData),
+        },
+        shows: {
+          ...data.shows,
+          search_result: (data.shows?.search_result ?? []).map(transformShowData),
+        },
+      };
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.booths?.next || lastPage.shows?.next) {
+        return allPages.length * LIMIT;
+      }
+      return undefined;
+    },
+    initialPageParam: 0,
+    enabled: !!query,
+  });
+
+  const booths = useMemo(
+    () => queryResult.data?.pages.flatMap((p) => p.booths.search_result) ?? [],
+    [queryResult.data],
+  );
+
+  const shows = useMemo(
+    () => queryResult.data?.pages.flatMap((p) => p.shows.search_result) ?? [],
+    [queryResult.data],
+  );
+
+  const boothCount = queryResult.data?.pages[0]?.booths?.counts ?? 0;
+  const showCount = queryResult.data?.pages[0]?.shows?.counts ?? 0;
+
+  return { ...queryResult, booths, shows, boothCount, showCount };
+};

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1,14 +1,42 @@
 /**
  * 검색 페이지
  */
+
+import { useEffect } from 'react';
+import { useSearch, usePopularKeywords } from '@/hooks';
+import useAlertStore from '@/store/useAlertStore';
 import Header from '@/components/Header';
 import Chip from '@/components/Chip';
 import useSearchStore from '@/store/useSearchStore';
-import { useSearch } from '@/hooks';
 
 const SearchPage = () => {
   const { recentSearches, removeRecentSearch, clearRecentSearches } = useSearchStore();
   const { executeSearch } = useSearch();
+  const openAlert = useAlertStore((s) => s.openAlert);
+  const closeAlert = useAlertStore((s) => s.closeAlert);
+  const { data: popularData, isError } = usePopularKeywords();
+
+  useEffect(() => {
+    if (isError) {
+      openAlert({
+        variant: 'error',
+        title: '인기 검색어 조회 오류',
+        text: (
+          <>
+            인기 검색어를 불러오지 못했어요.
+            <br />
+            잠시 후 다시 시도해주세요.
+          </>
+        ),
+        onConfirm: closeAlert,
+      });
+    }
+  }, [isError]);
+
+  const popularKeywords = popularData?.results ?? [];
+  const updatedAt = popularData?.updated_at
+    ? new Date(popularData.updated_at).toLocaleString('ko-KR', { hour: 'numeric', hour12: true })
+    : '';
 
   // Chip 또는 인기 검색어 클릭 시 검색 실행
   const handleSearchClick = (query) => {
@@ -54,31 +82,17 @@ const SearchPage = () => {
         <div className="flex flex-col gap-4">
           <div className="flex items-center justify-between">
             <h1 className="text-lg font-semibold text-gray-900">인기 검색어</h1>
-            <p className="text-xs font-normal text-gray-300">오전 12시 업데이트</p>
+            <p className="text-xs font-normal text-gray-300">{updatedAt} 업데이트</p>
           </div>
           <div className="grid grid-cols-2 gap-x-5 gap-y-3">
-            {/* 왼쪽 열: 1~5 */}
-            {[1, 2, 3, 4, 5].map((rank) => (
+            {popularKeywords.map(({ rank, keyword }) => (
               <div key={rank} className="flex items-center gap-3">
                 <span className="text-sm font-semibold text-gray-500">{rank}</span>
                 <button
-                  onClick={() => handleSearchClick(`인기검색어${rank}`)}
+                  onClick={() => handleSearchClick(keyword)}
                   className="text-sm font-medium text-gray-900"
                 >
-                  인기검색어{rank}
-                </button>
-              </div>
-            ))}
-
-            {/* 오른쪽 열: 6~10 */}
-            {[6, 7, 8, 9, 10].map((rank) => (
-              <div key={rank} className="flex items-center gap-3">
-                <span className="text-sm font-semibold text-gray-500">{rank}</span>
-                <button
-                  onClick={() => handleSearchClick(`인기검색어${rank}`)}
-                  className="text-sm font-medium text-gray-900"
-                >
-                  인기검색어{rank}
+                  {keyword}
                 </button>
               </div>
             ))}

--- a/src/pages/my/ScrapBooth.jsx
+++ b/src/pages/my/ScrapBooth.jsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import useFilterStore from '@/store/useFilterStore';
+import useLoadingStore from '@/store/useLoadingStore';
 import { useMyScrapBooths } from '@/hooks/useMyScrap';
 
 import FilterBar from '@/components/FilterBar';
@@ -22,6 +23,12 @@ const ScrapBooth = () => {
   const { booths, totalCount, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useMyScrapBooths(scrapBoothFilters);
 
+  const { showLoading, hideLoading } = useLoadingStore();
+  useEffect(() => {
+    if (isLoading) showLoading();
+    else hideLoading();
+  }, [isLoading]);
+
   const handleBoothExcludeEndedChange = (value) => {
     setFilter('scrap_booth', 'excludeEnded', value);
   };
@@ -31,7 +38,6 @@ const ScrapBooth = () => {
     scrapBoothFilters.location.length > 0 ||
     scrapBoothFilters.host.length > 0 ||
     scrapBoothFilters.day.length > 0 ||
-    scrapBoothFilters.sort !== null ||
     scrapBoothFilters.excludeEnded;
 
   // 윈도우 스크롤 기반 무한 스크롤
@@ -63,9 +69,6 @@ const ScrapBooth = () => {
             <DropDown type="scrap_booth" />
           </div>
         </div>
-
-        {/* 로딩 */}
-        {isLoading && <div className="py-24 text-center text-zinc-300">로딩 중...</div>}
 
         {/* 에러 */}
         {isError && (

--- a/src/pages/my/ScrapShow.jsx
+++ b/src/pages/my/ScrapShow.jsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import useFilterStore from '@/store/useFilterStore';
+import useLoadingStore from '@/store/useLoadingStore';
 import { useMyScrapShows } from '@/hooks/useMyScrap';
 
 import FilterBar from '@/components/FilterBar';
@@ -22,6 +23,12 @@ const ScrapShow = () => {
   const { shows, totalCount, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useMyScrapShows(scrapShowFilters);
 
+  const { showLoading, hideLoading } = useLoadingStore();
+  useEffect(() => {
+    if (isLoading) showLoading();
+    else hideLoading();
+  }, [isLoading]);
+
   const handleShowExcludeEndedChange = (value) => {
     setFilter('scrap_show', 'excludeEnded', value);
   };
@@ -30,7 +37,6 @@ const ScrapShow = () => {
     scrapShowFilters.category.length > 0 ||
     scrapShowFilters.host.length > 0 ||
     scrapShowFilters.day.length > 0 ||
-    scrapShowFilters.sort !== null ||
     scrapShowFilters.excludeEnded;
 
   // 윈도우 스크롤 기반 무한 스크롤
@@ -62,9 +68,6 @@ const ScrapShow = () => {
             <DropDown type="scrap_show" />
           </div>
         </div>
-
-        {/* 로딩 */}
-        {isLoading && <div className="py-24 text-center text-zinc-300">로딩 중...</div>}
 
         {/* 에러 */}
         {isError && (


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->

- close #125

<br />

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- 인기 검색어 API 연결 (`/searchs/popular/`) — TanStack Query 30분 캐싱 적용
- 검색 API 연결 (`/searchs/`) — `useSearchResults` hook 추가, 검색 시 기존 부스/공연 목록 시트에서 결과 표시
- SearchBar 뒤로가기 버튼 동작 개선 — `location.key !== 'default'` 기반 네비게이션, blur/click 이벤트 충돌 수정, 중복 `/search` 이동 방지
- Header 뒤로가기도 동일하게 수정
- 스크랩 토글 시 `myProfile` 쿼리 invalidate 추가
- 부스/공연 목록 및 스크랩 목록 로딩 상태를 텍스트 → 로딩 스피너/로딩 컴포넌트로 교체
- 검색 페이지 라우트 중복 제거

<br />

## 📸 UI 작업 시

<!-- 이미지 or 영상 or 프리뷰 링크 첨부 -->
<!-- 프리뷰 링크에 해당 페이지의 라우트 경로까지 포함하여 작성 -->

<br />

## 💬 To. Reviewer (선택)
백엔드 500에러 때문에 검색 결과 출력 화면을 테스트해보진 못했습니다.
다만 지도 연결을 위해서 해당 로직이 반영이 되어야해서 코드리뷰 후 approve 부탁드립니다!

<br />

## ✅ 체크 리스트

- [x] main 브랜치 pull 완료
- [x] Reviewers 설정
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정
