### PR TITLE
메뉴카드, 부스/공연 상세페이지 수정, 가격 입력 input 쉼표(,) 추가

### DIFF
--- a/src/components/Card/MenuCard.jsx
+++ b/src/components/Card/MenuCard.jsx
@@ -30,11 +30,11 @@ const MenuCard = ({ name, description, price, image, isSelling = true, onImageCl
               </h2>
               {!isSelling && <Badge size="sm" />}
             </div>
-            <p className="line-clamp-2 overflow-hidden text-xs leading-4 font-normal tracking-normal text-ellipsis text-zinc-500">
+            <p className="line-clamp-3 overflow-hidden text-xs leading-4 font-normal tracking-normal text-ellipsis text-zinc-500">
               {description}
             </p>
           </div>
-          <h3 className="line-clamp-1 overflow-hidden text-sm leading-5 font-semibold tracking-normal text-ellipsis text-zinc-800">
+          <h3 className="text-sm leading-5 font-semibold tracking-normal text-zinc-800">
             {(price ?? 0).toLocaleString()}원
           </h3>
         </div>

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -16,6 +16,7 @@ const Input = ({
   onChange,
   onSubmit,
   maxLength,
+  maxLengthCountMode = 'raw',
   error = false,
   variant = 'square',
   placeholder = '',
@@ -28,7 +29,11 @@ const Input = ({
   const hasCounter = !!maxLength;
   const showBottom = hasHelper || hasCounter;
 
-  const currentLength = value?.length ?? 0;
+  const normalizedValue = String(value ?? '');
+  const currentLength =
+    maxLengthCountMode === 'digits'
+      ? normalizedValue.replace(/\D/g, '').length
+      : normalizedValue.length;
 
   const justify =
     hasHelper && hasCounter ? 'justify-between' : hasHelper ? 'justify-start' : 'justify-end';
@@ -58,7 +63,7 @@ const Input = ({
         placeholder={placeholder}
         onChange={(e) => {
           let next = e.target.value;
-          if (maxLength && next.length > maxLength) {
+          if (maxLength && maxLengthCountMode === 'raw' && next.length > maxLength) {
             next = next.slice(0, maxLength);
           }
           onChange?.(next);

--- a/src/features/booth/BoothDetailSheet.jsx
+++ b/src/features/booth/BoothDetailSheet.jsx
@@ -135,7 +135,7 @@ const BoothDetailSheet = () => {
                 )}
 
                 {booth.description && (
-                  <p className="line-clamp-2 max-h-10 self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                  <p className="self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
                     {booth.description}
                   </p>
                 )}

--- a/src/features/show/ShowDetailSheet.jsx
+++ b/src/features/show/ShowDetailSheet.jsx
@@ -147,7 +147,7 @@ const ShowDetailSheet = () => {
                 )}
 
                 {show.description && (
-                  <p className="line-clamp-2 max-h-10 self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
+                  <p className="self-stretch text-sm leading-5 font-normal tracking-normal text-zinc-500">
                     {show.description}
                   </p>
                 )}

--- a/src/pages/admin/BoothEditPage.jsx
+++ b/src/pages/admin/BoothEditPage.jsx
@@ -32,6 +32,16 @@ const ERROR_TEXT_STYLE = {
   color: 'var(--System-normal, #FF5B5E)',
 };
 const DAYS = ['05.20', '05.21', '05.22'];
+const PRICE_MAX_DIGITS = 10;
+
+const formatPrice = (value) => {
+  const digits = String(value ?? '')
+    .replace(/\D/g, '')
+    .slice(0, PRICE_MAX_DIGITS);
+  return digits ? Number(digits).toLocaleString('en-US') : '';
+};
+
+const parsePrice = (value) => Number(String(value ?? '').replace(/,/g, ''));
 
 const BoothEditPage = () => {
   const { id } = useParams();
@@ -171,6 +181,7 @@ const BoothEditPage = () => {
         ...p,
         _tempId: crypto.randomUUID(),
         status: p.is_selling ? '판매중' : '종료',
+        price: formatPrice(p.price),
         image: p.image || null,
       })),
     );
@@ -460,12 +471,25 @@ const BoothEditPage = () => {
 
     formData.append('schedule', JSON.stringify(schedulePayload));
 
-    // 5. notice
-    const noticePayload = notices.map((n) => ({
-      ...(n.id ? { id: n.id } : {}),
-      title: n.title,
-      content: n.content,
-    }));
+    // 5. notice (신규/수정된 공지만 전송)
+    const originalNoticeMap = new Map(
+      originNotices.filter((n) => n.id).map((n) => [n.id, { title: n.title, content: n.content }]),
+    );
+
+    const noticePayload = notices
+      .filter((n) => {
+        if (!n.id) return true;
+
+        const original = originalNoticeMap.get(n.id);
+        if (!original) return true;
+
+        return n.title !== original.title || n.content !== original.content;
+      })
+      .map((n) => ({
+        ...(n.id ? { id: n.id } : {}),
+        title: n.title,
+        content: n.content,
+      }));
 
     formData.append('notice', JSON.stringify(noticePayload));
 
@@ -483,7 +507,7 @@ const BoothEditPage = () => {
           id: i.id || undefined,
           name: i.name,
           description: i.description,
-          price: Number(i.price),
+          price: parsePrice(i.price),
           is_selling: i.status === '판매중',
         };
       });
@@ -914,15 +938,16 @@ const BoothEditPage = () => {
                         variant="square_white"
                         value={item.price}
                         onChange={(value) => {
-                          if (!/^\d*$/.test(value)) {
+                          if (!/^[\d,]*$/.test(value)) {
                             showToast('가격은 숫자로만 입력해주세요.', 'warn');
                             return;
                           }
 
-                          handleItemChange(idx, 'price', value);
+                          handleItemChange(idx, 'price', formatPrice(value));
                         }}
                         placeholder="가격을 입력해주세요"
-                        maxLength="10"
+                        maxLength={PRICE_MAX_DIGITS}
+                        maxLengthCountMode="digits"
                         error={!!errors.items[idx]?.price}
                       />
                     </div>


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->

- close #00

<br />

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- 메뉴카드 설명 clamp 수를 3줄로 변경, price는 10글자여도 카드 최소 영역을 벗어날 일이 없어 clamp 제거
- 부스/공연 상세페이지 설명 clamp 제거
- 부스 수정페이지에서 가격 입력 input 자동으로 세자리수마다 , 추가되게 하도록 기능 추가

<br />

## 📸 UI 작업 시

<!-- 이미지 or 영상 or 프리뷰 링크 첨부 -->
<!-- 프리뷰 링크에 해당 페이지의 라우트 경로까지 포함하여 작성 -->

<br />

## 💬 To. Reviewer (선택)

<br />

## ✅ 체크 리스트

- [ ] main 브랜치 pull 완료
- [ ] Reviewers 설정
- [ ] Assignees 설정
- [ ] Labels 설정
- [ ] Projects 설정
- [ ] Milestone 설정
