### PR TITLE
부스/공연 수정 페이지: 이미지 압축 · 미디어 URL 보정 · SNS/에러 처리 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query-devtools": "^5.100.1",
     "autoprefixer": "^10.4.23",
     "axios": "^1.13.2",
+    "browser-image-compression": "^2.0.2",
     "postcss": "^8.5.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/components/Card/BoothCard.jsx
+++ b/src/components/Card/BoothCard.jsx
@@ -4,6 +4,7 @@
 
 import Badge from '@/components/Badge';
 import ScrapButton from '@/components/ScrapButton';
+import { resolveMediaUrl } from '@/utils/mediaUrl';
 
 const BoothCard = ({ booth, onClick }) => {
   if (!booth) return null;
@@ -59,7 +60,7 @@ const BoothCard = ({ booth, onClick }) => {
       <div className="mt-2.5 flex items-center gap-2 p-0">
         {/* 썸네일 */}
         <img
-          src={thumbnail || '/icons/default-image.svg'}
+          src={resolveMediaUrl(thumbnail) || '/icons/default-image.svg'}
           alt={name}
           className="h-20 w-20 rounded-md border border-zinc-100 object-cover"
         />
@@ -69,7 +70,7 @@ const BoothCard = ({ booth, onClick }) => {
           images.map((img, idx) => (
             <img
               key={idx}
-              src={img}
+              src={resolveMediaUrl(img)}
               alt={`${name} 상품 ${idx + 1}`}
               className="h-20 w-20 rounded-md border border-zinc-100 object-cover"
             />

--- a/src/components/Card/ShowCard.jsx
+++ b/src/components/Card/ShowCard.jsx
@@ -4,6 +4,7 @@
 
 import Badge from '@/components/Badge';
 import ScrapButton from '@/components/ScrapButton';
+import { resolveMediaUrl } from '@/utils/mediaUrl';
 
 const ShowCard = ({ show, onClick }) => {
   if (!show) return null;
@@ -31,7 +32,7 @@ const ShowCard = ({ show, onClick }) => {
     >
       {/* 공연 이미지 */}
       <img
-        src={thumbnail || '/icons/default-image.svg'}
+        src={resolveMediaUrl(thumbnail) || '/icons/default-image.svg'}
         alt={name}
         className="flex aspect-square h-20 w-20 items-center justify-center rounded-md border border-zinc-100 object-cover"
       />

--- a/src/components/FileUploader.jsx
+++ b/src/components/FileUploader.jsx
@@ -25,7 +25,7 @@ const useImagePreview = (image) => {
   return previewUrl;
 };
 
-export const DetailImageUploader = ({ image, onChange, onRemove }) => {
+export const DetailImageUploader = ({ image, onChange, onRemove, isLoading = false }) => {
   const inputRef = useRef(null);
   const previewUrl = useImagePreview(image);
 
@@ -55,6 +55,11 @@ export const DetailImageUploader = ({ image, onChange, onRemove }) => {
           </div>
         )}
       </div>
+      {isLoading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-black/40">
+          <div className="size-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+        </div>
+      )}
       {image && (
         <button
           className="absolute top-1 right-1 p-0.5"
@@ -70,7 +75,7 @@ export const DetailImageUploader = ({ image, onChange, onRemove }) => {
   );
 };
 
-export const ThumbnailImageUploader = ({ image, onChange, onRemove }) => {
+export const ThumbnailImageUploader = ({ image, onChange, onRemove, isLoading = false }) => {
   const inputRef = useRef(null);
   const previewUrl = useImagePreview(image);
 
@@ -90,6 +95,11 @@ export const ThumbnailImageUploader = ({ image, onChange, onRemove }) => {
         src={previewUrl || '/images/default-image-large.png'}
         className="absolute inset-0 h-full w-full object-cover"
       />
+      {isLoading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/40">
+          <div className="size-8 animate-spin rounded-full border-[3px] border-white border-t-transparent" />
+        </div>
+      )}
       <div className="absolute bottom-0 flex h-12 w-full cursor-pointer items-center justify-center bg-black/50">
         {!image ? (
           <button

--- a/src/features/booth/BoothDetailSheet.jsx
+++ b/src/features/booth/BoothDetailSheet.jsx
@@ -24,6 +24,7 @@ import Divider from '@/components/Divider';
 import NoticeCard from '@/components/Card/NoticeCard';
 import Tab from '@/components/Tab';
 import MenuCard from '@/components/Card/MenuCard';
+import { resolveMediaUrl } from '@/utils/mediaUrl';
 
 const BoothDetailSheet = () => {
   const { id } = useParams();
@@ -86,10 +87,10 @@ const BoothDetailSheet = () => {
           <>
             <Header left="back" />
             <img
-              src={booth.thumbnail || '/images/default-image-large.png'}
+              src={resolveMediaUrl(booth.thumbnail) || '/images/default-image-large.png'}
               className={`${booth.thumbnail ? 'cursor-pointer' : 'cursor-default'} flex aspect-49/30 w-full items-center justify-center object-cover`}
               onClick={() => {
-                if (booth.thumbnail) openImageModal(booth.thumbnail);
+                if (booth.thumbnail) openImageModal(resolveMediaUrl(booth.thumbnail));
               }}
             />
           </>
@@ -185,7 +186,7 @@ const BoothDetailSheet = () => {
                           <img src="/icons/icon-eclipse-gray.svg" />
                           <button
                             className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
-                            onClick={() => openImageModal(booth.roadview)}
+                            onClick={() => openImageModal(resolveMediaUrl(booth.roadview))}
                           >
                             로드뷰
                           </button>
@@ -261,7 +262,7 @@ const BoothDetailSheet = () => {
                           key={item.id}
                           name={item.name}
                           description={item.description}
-                          image={item.image}
+                          image={resolveMediaUrl(item.image)}
                           price={item.price}
                           isSelling={item.is_selling}
                           onImageClick={openImageModal}

--- a/src/features/booth/BoothDetailSheet.jsx
+++ b/src/features/booth/BoothDetailSheet.jsx
@@ -208,23 +208,16 @@ const BoothDetailSheet = () => {
                     SNS
                   </h3>
                   <div className="flex items-center gap-2.5">
-                    {snsLinks.instagram && (
-                      <img
-                        src="/icons/logo-instagramcolor.svg"
-                        className="h-7 w-7 cursor-pointer rounded-md"
-                        onClick={() => window.open(snsLinks.instagram, '_blank')}
-                      />
-                    )}
-
-                    {snsLinks.kakaotalk && (
-                      <img
-                        src="/icons/logo-kakaotalkcolor.svg"
-                        className="h-7 w-7 cursor-pointer rounded-md"
-                        onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
-                      />
-                    )}
-
-                    {!snsLinks.instagram && !snsLinks.kakaotalk && (
+                    {snsLinks.length > 0 ? (
+                      snsLinks.map((sns) => (
+                        <img
+                          key={sns.url}
+                          src={sns.icon}
+                          className="h-7 w-7 cursor-pointer rounded-md"
+                          onClick={() => window.open(sns.url, '_blank')}
+                        />
+                      ))
+                    ) : (
                       <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
                     )}
                   </div>

--- a/src/features/show/ShowDetailSheet.jsx
+++ b/src/features/show/ShowDetailSheet.jsx
@@ -220,23 +220,16 @@ const ShowDetailSheet = () => {
                     SNS
                   </h3>
                   <div className="flex items-center gap-2.5">
-                    {snsLinks.instagram && (
-                      <img
-                        src="/icons/logo-instagramcolor.svg"
-                        className="h-7 w-7 cursor-pointer rounded-md"
-                        onClick={() => window.open(snsLinks.instagram, '_blank')}
-                      />
-                    )}
-
-                    {snsLinks.kakaotalk && (
-                      <img
-                        src="/icons/logo-kakaotalkcolor.svg"
-                        className="h-7 w-7 cursor-pointer rounded-md"
-                        onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
-                      />
-                    )}
-
-                    {!snsLinks.instagram && !snsLinks.kakaotalk && (
+                    {snsLinks.length > 0 ? (
+                      snsLinks.map((sns) => (
+                        <img
+                          key={sns.url}
+                          src={sns.icon}
+                          className="h-7 w-7 cursor-pointer rounded-md"
+                          onClick={() => window.open(sns.url, '_blank')}
+                        />
+                      ))
+                    ) : (
                       <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
                     )}
                   </div>

--- a/src/features/show/ShowDetailSheet.jsx
+++ b/src/features/show/ShowDetailSheet.jsx
@@ -24,6 +24,7 @@ import Divider from '@/components/Divider';
 import NoticeCard from '@/components/Card/NoticeCard';
 import Tab from '@/components/Tab';
 import SetlistCard from '@/components/Card/SetlistCard';
+import { resolveMediaUrl } from '@/utils/mediaUrl';
 
 const ShowDetailSheet = () => {
   const { id } = useParams();
@@ -98,10 +99,10 @@ const ShowDetailSheet = () => {
           <>
             <Header left="back" />
             <img
-              src={show.thumbnail || '/images/default-image-large.png'}
+              src={resolveMediaUrl(show.thumbnail) || '/images/default-image-large.png'}
               className={`${show.thumbnail ? 'cursor-pointer' : 'cursor-default'} flex aspect-49/30 w-full items-center justify-center object-cover`}
               onClick={() => {
-                if (show.thumbnail) openImageModal(show.thumbnail);
+                if (show.thumbnail) openImageModal(resolveMediaUrl(show.thumbnail));
               }}
             />
           </>
@@ -197,7 +198,7 @@ const ShowDetailSheet = () => {
                           <img src="/icons/icon-eclipse-gray.svg" />
                           <button
                             className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
-                            onClick={() => openImageModal(show.roadview)}
+                            onClick={() => openImageModal(resolveMediaUrl(show.roadview))}
                           >
                             로드뷰
                           </button>

--- a/src/hooks/booth/useBoothDetail.js
+++ b/src/hooks/booth/useBoothDetail.js
@@ -6,6 +6,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import useToastStore from '@/store/useToastStore';
 import { BoothAPI } from '@/apis';
+import { getErrorMessage } from '@/utils/errorHelper';
 
 export const useBoothDetail = (id) => {
   return useQuery({
@@ -45,12 +46,7 @@ export const useUpdateBooth = (id, resourceVersion) => {
     },
     onError: (err) => {
       console.error('저장 실패:', err);
-
-      if (err.response?.status === 409) {
-        showToast('데이터가 변경되었습니다. 새로고침 후 다시 시도해주세요.', 'warn');
-      } else {
-        showToast('수정 중 오류가 발생했습니다.', 'warn');
-      }
+      showToast(getErrorMessage(err) || '수정 중 오류가 발생했습니다.', 'warn');
     },
   });
 };

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -2,6 +2,7 @@
 //사용하는 쪽에서 import { useIsMobile } from "@/hooks"; 이렇게 불러와서 사용
 
 export { default as useImageUploader } from './useImageUploader.js';
+export { default as useImageCompression } from './useImageCompression.js';
 export { useInfiniteList, buildQueryParams } from './useInfiniteList.js';
 export { useInfiniteScroll } from './useInfiniteScroll.js';
 export { default as useScrollToTop } from './useScrollToTop.js';

--- a/src/hooks/show/useShowDetail.js
+++ b/src/hooks/show/useShowDetail.js
@@ -6,6 +6,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import useToastStore from '@/store/useToastStore';
 import { ShowAPI } from '@/apis';
+import { getErrorMessage } from '@/utils/errorHelper';
 
 export const useShowDetail = (id) => {
   return useQuery({
@@ -45,12 +46,7 @@ export const useUpdateShow = (id, resourceVersion) => {
     },
     onError: (err) => {
       console.error('저장 실패:', err);
-
-      if (err.response?.status === 409) {
-        showToast('데이터가 변경되었습니다. 새로고침 후 다시 시도해주세요.', 'warn');
-      } else {
-        showToast('수정 중 오류가 발생했습니다.', 'warn');
-      }
+      showToast(getErrorMessage(err) || '수정 중 오류가 발생했습니다.', 'warn');
     },
   });
 };

--- a/src/hooks/useImageCompression.js
+++ b/src/hooks/useImageCompression.js
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react';
+import imageCompression from 'browser-image-compression';
+
+const DEFAULT_OPTIONS = {
+  maxSizeMB: 1, // 최대 1MB로 압축
+  maxWidthOrHeight: 1920, // 긴 변 최대 1920px
+  useWebWorker: true, // 메인 스레드 블로킹 방지
+};
+
+/**
+ * 이미지 파일을 업로드 전 클라이언트에서 압축하는 훅
+ * - 이미지가 아니거나 압축 실패 시 원본 파일을 그대로 반환
+ */
+const useImageCompression = () => {
+  const [isCompressing, setIsCompressing] = useState(false);
+
+  const compress = useCallback(async (file, options) => {
+    if (!file || !file.type?.startsWith('image/')) return file;
+
+    setIsCompressing(true);
+    try {
+      const compressed = await imageCompression(file, { ...DEFAULT_OPTIONS, ...options });
+
+      // browser-image-compression 은 .name 만 붙인 Blob 을 반환한다.
+      // FormData 전송 시 확장자가 보존되도록 원본 파일명을 가진 실제 File 로 다시 감싼다.
+      return new File([compressed], file.name, {
+        type: compressed.type || file.type,
+        lastModified: Date.now(),
+      });
+    } catch (error) {
+      console.error('이미지 압축 실패:', error);
+      return file; // 실패 시 원본 사용
+    } finally {
+      setIsCompressing(false);
+    }
+  }, []);
+
+  return { compress, isCompressing };
+};
+
+export default useImageCompression;

--- a/src/hooks/useImageUploader.js
+++ b/src/hooks/useImageUploader.js
@@ -1,11 +1,17 @@
 import { useState, useEffect } from 'react';
+import useImageCompression from './useImageCompression.js';
+import useToastStore from '@/store/useToastStore';
 
 const isBlobUrl = (url) => url?.startsWith('blob:');
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 const useImageUploader = (initialImage = null) => {
   const [image, setImage] = useState(initialImage);
   const [file, setFile] = useState(null); // 원본 파일 추가
   const [isDeleted, setIsDeleted] = useState(false);
+  const { compress, isCompressing } = useImageCompression();
+  const showToast = useToastStore((s) => s.showToast);
 
   useEffect(() => {
     if (file || isDeleted) return;
@@ -13,9 +19,15 @@ const useImageUploader = (initialImage = null) => {
     setImage(initialImage);
   }, [initialImage, file, isDeleted]);
 
-  const onSelectFile = (selectedFile) => {
+  const onSelectFile = async (selectedFile) => {
     if (!selectedFile) return;
 
+    if (selectedFile.size > MAX_FILE_SIZE) {
+      showToast('이미지는 최대 10MB까지 업로드할 수 있어요.', 'warn');
+      return;
+    }
+
+    // 미리보기는 원본으로 즉시 표시
     const url = URL.createObjectURL(selectedFile);
 
     setImage((prev) => {
@@ -23,7 +35,10 @@ const useImageUploader = (initialImage = null) => {
       return url;
     });
 
-    setFile(selectedFile); // 파일 저장
+    // 업로드용 파일은 압축본으로 저장
+    // (isDeleted 해제는 압축 완료 후 file 과 함께 처리 — 비동기 도중 미리보기가 초기화되는 것 방지)
+    const compressedFile = await compress(selectedFile);
+    setFile(compressedFile);
     setIsDeleted(false);
   };
 
@@ -42,7 +57,7 @@ const useImageUploader = (initialImage = null) => {
     };
   }, [image]);
 
-  return { image, file, isDeleted, onSelectFile, clearImage }; // file 추가
+  return { image, file, isDeleted, isCompressing, onSelectFile, clearImage }; // file 추가
 };
 
 export default useImageUploader;

--- a/src/pages/admin/BoothEditPage.jsx
+++ b/src/pages/admin/BoothEditPage.jsx
@@ -28,6 +28,7 @@ import Timepicker from '@/components/Timepicker';
 import Button from '@/components/Button';
 import { FESTIVAL_TIME } from '@/constants/time';
 import { resolveMediaUrl } from '@/utils/mediaUrl';
+import { isSnsUrl } from '@/utils/snsHelper';
 
 const ERROR_TEXT_CLASS = 'text-xs font-normal leading-4 font-normal tracking-0';
 const ERROR_TEXT_STYLE = {
@@ -391,6 +392,8 @@ const BoothEditPage = () => {
       name: '',
       category: '',
       schedule: '',
+      snsInstagram: '',
+      snsKakao: '',
       notices: [],
       items: [],
     };
@@ -399,6 +402,11 @@ const BoothEditPage = () => {
     if (selectedCategories.length === 0) newErrors.category = '카테고리를 1개 이상 선택해주세요.';
     if (!Object.values(schedule).some((d) => d.checked))
       newErrors.schedule = '운영 시간을 1개 이상 선택해주세요.';
+
+    if (form.snsInstagram.trim() && !isSnsUrl(form.snsInstagram))
+      newErrors.snsInstagram = '인스타그램 또는 카카오 URL을 입력해주세요.';
+    if (form.snsKakao.trim() && !isSnsUrl(form.snsKakao))
+      newErrors.snsKakao = '인스타그램 또는 카카오 URL을 입력해주세요.';
 
     newErrors.notices = notices.map((n) => ({
       title: !n.title.trim() ? '제목을 입력해주세요.' : '',
@@ -415,6 +423,8 @@ const BoothEditPage = () => {
       !newErrors.name &&
       !newErrors.category &&
       !newErrors.schedule &&
+      !newErrors.snsInstagram &&
+      !newErrors.snsKakao &&
       newErrors.notices.every((n) => !n.title && !n.content) &&
       newErrors.items.every((i) => !i.name && !i.description && !i.price);
 
@@ -535,7 +545,7 @@ const BoothEditPage = () => {
     }
 
     // 8. sns
-    const currentSns = [form.snsKakao, form.snsInstagram].filter((v) => v && v.trim() !== '');
+    const currentSns = [form.snsInstagram, form.snsKakao].filter((v) => v && v.trim() !== '');
 
     formData.append('sns', JSON.stringify(currentSns));
 
@@ -763,8 +773,14 @@ const BoothEditPage = () => {
                       value={form.snsInstagram}
                       onChange={(value) => handleChange('snsInstagram', value)}
                       placeholder="https://www.instagram.com/"
+                      error={!!errors.snsInstagram}
                     />
                   </div>
+                  {errors.snsInstagram && (
+                    <p className={`${ERROR_TEXT_CLASS} -mt-1.5 pl-9.5`} style={ERROR_TEXT_STYLE}>
+                      {errors.snsInstagram}
+                    </p>
+                  )}
                   <div className="flex items-center gap-3 self-stretch">
                     <img src="/icons/logo-kakaotalkcolor.svg" className="rounded-md" />
                     <Input
@@ -772,8 +788,14 @@ const BoothEditPage = () => {
                       value={form.snsKakao}
                       onChange={(value) => handleChange('snsKakao', value)}
                       placeholder="http://pf.kakao.com/"
+                      error={!!errors.snsKakao}
                     />
                   </div>
+                  {errors.snsKakao && (
+                    <p className={`${ERROR_TEXT_CLASS} -mt-1.5 pl-9.5`} style={ERROR_TEXT_STYLE}>
+                      {errors.snsKakao}
+                    </p>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/admin/BoothEditPage.jsx
+++ b/src/pages/admin/BoothEditPage.jsx
@@ -17,6 +17,7 @@ import {
   useUpdateBooth,
 } from '@/hooks';
 import { ThumbnailImageUploader, DetailImageUploader } from '@/components/FileUploader';
+import ProductItem from './ProductItem';
 import Input from '@/components/Input/Input';
 import Checkbox from '@/components/Checkbox';
 import Chip from '@/components/Chip';
@@ -26,6 +27,7 @@ import TextArea from '@/components/Input/TextArea';
 import Timepicker from '@/components/Timepicker';
 import Button from '@/components/Button';
 import { FESTIVAL_TIME } from '@/constants/time';
+import { resolveMediaUrl } from '@/utils/mediaUrl';
 
 const ERROR_TEXT_CLASS = 'text-xs font-normal leading-4 font-normal tracking-0';
 const ERROR_TEXT_STYLE = {
@@ -97,6 +99,7 @@ const BoothEditPage = () => {
     image: detailImage,
     file: detailFile,
     isDeleted: isRoadviewDeleted,
+    isCompressing: isDetailCompressing,
     onSelectFile: onDetailChange,
     clearImage: clearDetailImage,
   } = useImageUploader(originData?.roadview);
@@ -105,6 +108,7 @@ const BoothEditPage = () => {
     image: thumbnailImage,
     file: thumbnailFile,
     isDeleted: isThumbnailDeleted,
+    isCompressing: isThumbnailCompressing,
     onSelectFile: onThumbnailChange,
     clearImage: clearThumbnailImage,
   } = useImageUploader(originData?.thumbnail);
@@ -117,21 +121,22 @@ const BoothEditPage = () => {
   const [errors, setErrors] = useState({ notices: [], items: [] });
   const [isFormValid, setIsFormValid] = useState(false);
 
+  // 상품 이미지 압축 진행 개수 (저장 버튼 활성화 제어용)
+  const [compressingCount, setCompressingCount] = useState(0);
+  const handleItemCompressingChange = useCallback((isCompressing) => {
+    setCompressingCount((count) => count + (isCompressing ? 1 : -1));
+  }, []);
+  const isAnyImageCompressing =
+    isThumbnailCompressing || isDetailCompressing || compressingCount > 0;
+
   // 1. 데이터 초기화 (쿼리 결과를 폼 state로 한 번만 populate)
   useEffect(() => {
     if (!boothData || !noticesData || originData) return;
 
-    const sanitizeUrl = (url) => {
-      if (!url) return url;
-      return url
-        .replace(/^http:\/\//, 'https://')
-        .replace(/[^:/?#]+(?=[/?#]|$)/g, (segment) => encodeURIComponent(segment));
-    };
-
     const safeData = {
       ...boothData,
-      thumbnail: sanitizeUrl(boothData.thumbnail),
-      roadview: sanitizeUrl(boothData.roadview),
+      thumbnail: resolveMediaUrl(boothData.thumbnail),
+      roadview: resolveMediaUrl(boothData.roadview),
     };
 
     setOriginData(safeData);
@@ -181,7 +186,7 @@ const BoothEditPage = () => {
         _tempId: crypto.randomUUID(),
         status: p.is_selling ? '판매중' : '종료',
         price: formatPrice(p.price),
-        image: p.image || null,
+        image: resolveMediaUrl(p.image) || null,
       })),
     );
   }, [boothData, noticesData, originData]);
@@ -278,10 +283,16 @@ const BoothEditPage = () => {
     ]);
   };
 
-  const handleItemChange = (idx, field, value) => {
-    const newItems = [...items];
-    newItems[idx][field] = value;
-    setItems(newItems);
+  const handleItemChange = useCallback((idx, field, value) => {
+    setItems((prev) => prev.map((it, i) => (i === idx ? { ...it, [field]: value } : it)));
+  }, []);
+
+  const handleItemPriceChange = (idx, value) => {
+    if (!/^[\d,]*$/.test(value)) {
+      showToast('가격은 숫자로만 입력해주세요.', 'warn');
+      return;
+    }
+    handleItemChange(idx, 'price', formatPrice(value));
   };
 
   // 이미지 삭제 alert
@@ -539,7 +550,7 @@ const BoothEditPage = () => {
         left="back"
         right="save"
         onSave={handleSave}
-        saveDisabled={!isFormValid}
+        saveDisabled={!isFormValid || isAnyImageCompressing}
         onBack={handleBack}
       />
 
@@ -548,6 +559,7 @@ const BoothEditPage = () => {
           image={thumbnailImage}
           onChange={onThumbnailChange}
           onRemove={() => handleClickRemove(clearThumbnailImage)}
+          isLoading={isThumbnailCompressing}
         />
 
         <div className="flex w-full flex-col items-center gap-6 px-5 pt-5 pb-6">
@@ -721,6 +733,7 @@ const BoothEditPage = () => {
                     image={detailImage}
                     onChange={onDetailChange}
                     onRemove={() => handleClickRemove(clearDetailImage)}
+                    isLoading={isDetailCompressing}
                   />
                 </div>
 
@@ -857,125 +870,18 @@ const BoothEditPage = () => {
               <Divider />
               <div className="flex w-full flex-col gap-10 self-stretch bg-zinc-50 px-5 py-6">
                 {items.map((item, idx) => (
-                  <div
+                  <ProductItem
                     key={item.id ?? item._tempId}
-                    className="flex w-full flex-col items-start gap-3"
-                  >
-                    {idx !== 0 && (
-                      <>
-                        <Divider />
-                        <div className="pt-5" />
-                      </>
-                    )}
-                    {/* 상태 */}
-                    <div className="flex items-center gap-1 self-stretch pb-5.5">
-                      <h3 className="flex items-start pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
-                        상태
-                      </h3>
-                      <div className="flex items-center gap-1.5">
-                        <Chip
-                          variant="state"
-                          text="판매중"
-                          isSelected={item.status === '판매중'}
-                          onClick={() => handleItemChange(idx, 'status', '판매중')}
-                        />
-                        <Chip
-                          variant="state"
-                          text="종료"
-                          isSelected={item.status === '종료'}
-                          onClick={() => handleItemChange(idx, 'status', '종료')}
-                        />
-                      </div>
-                    </div>
-
-                    {/* 이름 */}
-                    <div className="flex w-full items-start self-stretch">
-                      <h3 className="flex w-9 items-start pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
-                        이름
-                      </h3>
-                      <Input
-                        variant="square_white"
-                        value={item.name}
-                        onChange={(value) => handleItemChange(idx, 'name', value)}
-                        placeholder="이름을 입력해주세요"
-                        maxLength="15"
-                        error={!!errors.items[idx]?.name}
-                      />
-                    </div>
-                    {errors.items[idx]?.name && (
-                      <p className={`${ERROR_TEXT_CLASS} -mt-7 pl-8.5`} style={ERROR_TEXT_STYLE}>
-                        {errors.items[idx].name}
-                      </p>
-                    )}
-
-                    {/* 설명 */}
-                    <TextArea
-                      label="설명"
-                      value={item.description}
-                      onChange={(value) => handleItemChange(idx, 'description', value)}
-                      labelPosition="left"
-                      placeholder="설명을 입력해주세요"
-                      maxLength="45"
-                      error={!!errors.items[idx]?.description}
-                    />
-                    {errors.items[idx]?.description && (
-                      <p className={`${ERROR_TEXT_CLASS} -mt-7 pl-8.5`} style={ERROR_TEXT_STYLE}>
-                        {errors.items[idx].description}
-                      </p>
-                    )}
-
-                    {/* 가격 */}
-                    <div className="flex w-full items-start self-stretch pb-5.5">
-                      <h3 className="flex w-9 items-start pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
-                        가격
-                      </h3>
-                      <Input
-                        variant="square_white"
-                        value={item.price}
-                        onChange={(value) => {
-                          if (!/^[\d,]*$/.test(value)) {
-                            showToast('가격은 숫자로만 입력해주세요.', 'warn');
-                            return;
-                          }
-
-                          handleItemChange(idx, 'price', formatPrice(value));
-                        }}
-                        placeholder="가격을 입력해주세요"
-                        maxLength={PRICE_MAX_DIGITS}
-                        maxLengthCountMode="digits"
-                        error={!!errors.items[idx]?.price}
-                      />
-                    </div>
-                    {errors.items[idx]?.price && (
-                      <p className={`${ERROR_TEXT_CLASS} -mt-7 pl-8.5`} style={ERROR_TEXT_STYLE}>
-                        {errors.items[idx].price}
-                      </p>
-                    )}
-
-                    {/* 사진 */}
-                    <div className="flex w-full items-end justify-between self-stretch">
-                      <div className="flex items-start">
-                        <h2 className="flex w-9 pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
-                          사진
-                        </h2>
-                        <DetailImageUploader
-                          image={item.image}
-                          onChange={(file) => handleItemChange(idx, 'image', file)}
-                          onRemove={() =>
-                            handleClickRemove(() => handleItemChange(idx, 'image', null))
-                          }
-                        />
-                      </div>
-                      <Button
-                        variant="bg-pink"
-                        size="sm"
-                        circle="true"
-                        onClick={() => handleItemRemove(idx)}
-                      >
-                        삭제
-                      </Button>
-                    </div>
-                  </div>
+                    item={item}
+                    index={idx}
+                    error={errors.items[idx]}
+                    priceMaxDigits={PRICE_MAX_DIGITS}
+                    onChange={handleItemChange}
+                    onPriceChange={handleItemPriceChange}
+                    onRemoveItem={handleItemRemove}
+                    onRemoveImage={handleClickRemove}
+                    onCompressingChange={handleItemCompressingChange}
+                  />
                 ))}
                 <Button onClick={handleItemAdd} className="text-sm">
                   <img src="/icons/icon-addimage-white.svg" />

--- a/src/pages/admin/MyBoothPage.jsx
+++ b/src/pages/admin/MyBoothPage.jsx
@@ -206,23 +206,16 @@ const MyBoothPage = () => {
                 SNS
               </h3>
               <div className="flex items-center gap-2.5">
-                {snsLinks.instagram && (
-                  <img
-                    src="/icons/logo-instagramcolor.svg"
-                    className="h-7 w-7 cursor-pointer rounded-md"
-                    onClick={() => window.open(snsLinks.instagram, '_blank')}
-                  />
-                )}
-
-                {snsLinks.kakaotalk && (
-                  <img
-                    src="/icons/logo-kakaotalkcolor.svg"
-                    className="h-7 w-7 cursor-pointer rounded-md"
-                    onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
-                  />
-                )}
-
-                {!snsLinks.instagram && !snsLinks.kakaotalk && (
+                {snsLinks.length > 0 ? (
+                  snsLinks.map((sns) => (
+                    <img
+                      key={sns.url}
+                      src={sns.icon}
+                      className="h-7 w-7 cursor-pointer rounded-md"
+                      onClick={() => window.open(sns.url, '_blank')}
+                    />
+                  ))
+                ) : (
                   <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
                 )}
               </div>

--- a/src/pages/admin/MyBoothPage.jsx
+++ b/src/pages/admin/MyBoothPage.jsx
@@ -22,6 +22,7 @@ import Divider from '@/components/Divider';
 import NoticeCard from '@/components/Card/NoticeCard';
 import Tab from '@/components/Tab';
 import MenuCard from '@/components/Card/MenuCard';
+import { resolveMediaUrl } from '@/utils/mediaUrl';
 
 const MyBoothPage = () => {
   const { id } = useParams();
@@ -88,20 +89,14 @@ const MyBoothPage = () => {
     : '';
   const snsLinks = mapSnsUrls(booth.sns);
 
-  const fixUrl = (url) => {
-    if (!url) return url;
-    return url.replace('http://', 'https://');
-  };
-
-  console.log(booth.thumbnail);
   return (
     <>
       <Header left="back" right="edit" background="white" onEdit={goEditPage} onBack={goMyPage} />
       <img
-        src={fixUrl(booth.thumbnail || '/images/default-image-large.png')}
+        src={resolveMediaUrl(booth.thumbnail || '/images/default-image-large.png')}
         className={`${booth.thumbnail ? 'cursor-pointer' : 'cursor-default'} mt-18 flex aspect-49/30 w-full items-center justify-center object-cover`}
         onClick={() => {
-          if (booth.thumbnail) openImageModal(fixUrl(booth.thumbnail));
+          if (booth.thumbnail) openImageModal(resolveMediaUrl(booth.thumbnail));
         }}
       />
 
@@ -189,7 +184,7 @@ const MyBoothPage = () => {
                       <img src="/icons/icon-eclipse-gray.svg" />
                       <button
                         className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
-                        onClick={() => openImageModal(fixUrl(booth.roadview))}
+                        onClick={() => openImageModal(resolveMediaUrl(booth.roadview))}
                       >
                         로드뷰
                       </button>
@@ -265,10 +260,10 @@ const MyBoothPage = () => {
                       key={item.id}
                       name={item.name}
                       description={item.description}
-                      image={fixUrl(item.image)}
+                      image={resolveMediaUrl(item.image)}
                       price={item.price}
                       isSelling={item.is_selling}
-                      onImageClick={(img) => openImageModal(fixUrl(img))}
+                      onImageClick={(img) => openImageModal(resolveMediaUrl(img))}
                     />
                   ))
                 ) : (

--- a/src/pages/admin/MyShowPage.jsx
+++ b/src/pages/admin/MyShowPage.jsx
@@ -22,6 +22,7 @@ import Divider from '@/components/Divider';
 import NoticeCard from '@/components/Card/NoticeCard';
 import Tab from '@/components/Tab';
 import SetlistCard from '@/components/Card/SetlistCard';
+import { resolveMediaUrl } from '@/utils/mediaUrl';
 
 const MyShowPage = () => {
   const { id } = useParams();
@@ -105,10 +106,10 @@ const MyShowPage = () => {
     <>
       <Header left="back" right="edit" background="white" onEdit={goEditPage} onBack={goMyPage} />
       <img
-        src={show.thumbnail || '/images/default-image-large.png'}
+        src={resolveMediaUrl(show.thumbnail) || '/images/default-image-large.png'}
         className={`${show.thumbnail ? 'cursor-pointer' : 'cursor-default'} mt-18 flex aspect-49/30 w-full items-center justify-center object-cover`}
         onClick={() => {
-          if (show.thumbnail) openImageModal(show.thumbnail);
+          if (show.thumbnail) openImageModal(resolveMediaUrl(show.thumbnail));
         }}
       />
 
@@ -196,7 +197,7 @@ const MyShowPage = () => {
                       <img src="/icons/icon-eclipse-gray.svg" />
                       <button
                         className="text-sm leading-5 font-medium tracking-normal text-zinc-800 underline decoration-solid underline-offset-2"
-                        onClick={() => openImageModal(show.roadview)}
+                        onClick={() => openImageModal(resolveMediaUrl(show.roadview))}
                       >
                         로드뷰
                       </button>

--- a/src/pages/admin/MyShowPage.jsx
+++ b/src/pages/admin/MyShowPage.jsx
@@ -219,23 +219,16 @@ const MyShowPage = () => {
                 SNS
               </h3>
               <div className="flex items-center gap-2.5">
-                {snsLinks.instagram && (
-                  <img
-                    src="/icons/logo-instagramcolor.svg"
-                    className="h-7 w-7 cursor-pointer rounded-md"
-                    onClick={() => window.open(snsLinks.instagram, '_blank')}
-                  />
-                )}
-
-                {snsLinks.kakaotalk && (
-                  <img
-                    src="/icons/logo-kakaotalkcolor.svg"
-                    className="h-7 w-7 cursor-pointer rounded-md"
-                    onClick={() => window.open(snsLinks.kakaotalk, '_blank')}
-                  />
-                )}
-
-                {!snsLinks.instagram && !snsLinks.kakaotalk && (
+                {snsLinks.length > 0 ? (
+                  snsLinks.map((sns) => (
+                    <img
+                      key={sns.url}
+                      src={sns.icon}
+                      className="h-7 w-7 cursor-pointer rounded-md"
+                      onClick={() => window.open(sns.url, '_blank')}
+                    />
+                  ))
+                ) : (
                   <p className="text-sm leading-5 font-normal text-zinc-500">-</p>
                 )}
               </div>

--- a/src/pages/admin/ProductItem.jsx
+++ b/src/pages/admin/ProductItem.jsx
@@ -1,0 +1,158 @@
+/**
+ * 부스 수정 - 상품(리스트) 항목
+ * - 항목별로 useImageUploader 를 사용하기 위해 별도 컴포넌트로 분리
+ */
+
+import { useEffect } from 'react';
+import { useImageUploader } from '@/hooks';
+import { DetailImageUploader } from '@/components/FileUploader';
+import Input from '@/components/Input/Input';
+import TextArea from '@/components/Input/TextArea';
+import Chip from '@/components/Chip';
+import Button from '@/components/Button';
+import Divider from '@/components/Divider';
+
+const ERROR_TEXT_CLASS = 'text-xs font-normal leading-4 font-normal tracking-0';
+const ERROR_TEXT_STYLE = {
+  color: 'var(--System-normal, #FF5B5E)',
+};
+
+const ProductItem = ({
+  item,
+  index,
+  error,
+  priceMaxDigits,
+  onChange,
+  onPriceChange,
+  onRemoveItem,
+  onRemoveImage,
+  onCompressingChange,
+}) => {
+  const { image, file, isDeleted, isCompressing, onSelectFile, clearImage } = useImageUploader(
+    item.image,
+  );
+
+  // useImageUploader 의 이미지 변경을 부모 items[index].image 로 동기화
+  useEffect(() => {
+    if (file) onChange(index, 'image', file);
+  }, [file, index, onChange]);
+
+  useEffect(() => {
+    if (isDeleted) onChange(index, 'image', null);
+  }, [isDeleted, index, onChange]);
+
+  // 압축 진행 상태를 부모로 전달 (저장 버튼 활성화 제어용)
+  useEffect(() => {
+    if (!isCompressing) return;
+    onCompressingChange(true);
+    return () => onCompressingChange(false);
+  }, [isCompressing, onCompressingChange]);
+
+  return (
+    <div className="flex w-full flex-col items-start gap-3">
+      {index !== 0 && (
+        <>
+          <Divider />
+          <div className="pt-5" />
+        </>
+      )}
+      {/* 상태 */}
+      <div className="flex items-center gap-1 self-stretch pb-5.5">
+        <h3 className="flex items-start pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
+          상태
+        </h3>
+        <div className="flex items-center gap-1.5">
+          <Chip
+            variant="state"
+            text="판매중"
+            isSelected={item.status === '판매중'}
+            onClick={() => onChange(index, 'status', '판매중')}
+          />
+          <Chip
+            variant="state"
+            text="종료"
+            isSelected={item.status === '종료'}
+            onClick={() => onChange(index, 'status', '종료')}
+          />
+        </div>
+      </div>
+
+      {/* 이름 */}
+      <div className="flex w-full items-start self-stretch">
+        <h3 className="flex w-9 items-start pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
+          이름
+        </h3>
+        <Input
+          variant="square_white"
+          value={item.name}
+          onChange={(value) => onChange(index, 'name', value)}
+          placeholder="이름을 입력해주세요"
+          maxLength="15"
+          error={!!error?.name}
+        />
+      </div>
+      {error?.name && (
+        <p className={`${ERROR_TEXT_CLASS} -mt-7 pl-8.5`} style={ERROR_TEXT_STYLE}>
+          {error.name}
+        </p>
+      )}
+
+      {/* 설명 */}
+      <TextArea
+        label="설명"
+        value={item.description}
+        onChange={(value) => onChange(index, 'description', value)}
+        labelPosition="left"
+        placeholder="설명을 입력해주세요"
+        maxLength="45"
+        error={!!error?.description}
+      />
+      {error?.description && (
+        <p className={`${ERROR_TEXT_CLASS} -mt-7 pl-8.5`} style={ERROR_TEXT_STYLE}>
+          {error.description}
+        </p>
+      )}
+
+      {/* 가격 */}
+      <div className="flex w-full items-start self-stretch pb-5.5">
+        <h3 className="flex w-9 items-start pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
+          가격
+        </h3>
+        <Input
+          variant="square_white"
+          value={item.price}
+          onChange={(value) => onPriceChange(index, value)}
+          placeholder="가격을 입력해주세요"
+          maxLength={priceMaxDigits}
+          maxLengthCountMode="digits"
+          error={!!error?.price}
+        />
+      </div>
+      {error?.price && (
+        <p className={`${ERROR_TEXT_CLASS} -mt-7 pl-8.5`} style={ERROR_TEXT_STYLE}>
+          {error.price}
+        </p>
+      )}
+
+      {/* 사진 */}
+      <div className="flex w-full items-end justify-between self-stretch">
+        <div className="flex items-start">
+          <h2 className="flex w-9 pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
+            사진
+          </h2>
+          <DetailImageUploader
+            image={image}
+            onChange={onSelectFile}
+            onRemove={() => onRemoveImage(clearImage)}
+            isLoading={isCompressing}
+          />
+        </div>
+        <Button variant="bg-pink" size="sm" circle="true" onClick={() => onRemoveItem(index)}>
+          삭제
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ProductItem;

--- a/src/pages/admin/ProductItem.jsx
+++ b/src/pages/admin/ProductItem.jsx
@@ -114,7 +114,7 @@ const ProductItem = ({
       )}
 
       {/* 가격 */}
-      <div className="flex w-full items-start self-stretch pb-5.5">
+      <div className="flex w-full items-start self-stretch">
         <h3 className="flex w-9 items-start pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
           가격
         </h3>
@@ -135,7 +135,7 @@ const ProductItem = ({
       )}
 
       {/* 사진 */}
-      <div className="flex w-full items-end justify-between self-stretch">
+      <div className="flex w-full items-end justify-between self-stretch pt-5.5">
         <div className="flex items-start">
           <h2 className="flex w-9 pr-2 text-sm leading-5 font-semibold tracking-normal text-zinc-800">
             사진

--- a/src/pages/admin/ShowEditPage.jsx
+++ b/src/pages/admin/ShowEditPage.jsx
@@ -27,6 +27,7 @@ import TextArea from '@/components/Input/TextArea';
 import Timepicker from '@/components/Timepicker';
 import Button from '@/components/Button';
 import { FESTIVAL_TIME } from '@/constants/time';
+import { resolveMediaUrl } from '@/utils/mediaUrl';
 
 const ERROR_TEXT_CLASS = 'text-xs font-normal leading-4 font-normal tracking-0';
 const ERROR_TEXT_STYLE = {
@@ -89,6 +90,7 @@ const ShowEditPage = () => {
     image: detailImage,
     file: detailFile,
     isDeleted: isRoadviewDeleted,
+    isCompressing: isDetailCompressing,
     onSelectFile: onDetailChange,
     clearImage: clearDetailImage,
   } = useImageUploader(originData?.roadview);
@@ -97,6 +99,7 @@ const ShowEditPage = () => {
     image: thumbnailImage,
     file: thumbnailFile,
     isDeleted: isThumbnailDeleted,
+    isCompressing: isThumbnailCompressing,
     onSelectFile: onThumbnailChange,
     clearImage: clearThumbnailImage,
   } = useImageUploader(originData?.thumbnail);
@@ -113,17 +116,10 @@ const ShowEditPage = () => {
   useEffect(() => {
     if (!showData || !noticesData || originData) return;
 
-    const sanitizeUrl = (url) => {
-      if (!url) return url;
-      return url
-        .replace(/^http:\/\//, 'https://')
-        .replace(/[^:/?#]+(?=[/?#]|$)/g, (segment) => encodeURIComponent(segment));
-    };
-
     const safeData = {
       ...showData,
-      thumbnail: sanitizeUrl(showData.thumbnail),
-      roadview: sanitizeUrl(showData.roadview),
+      thumbnail: resolveMediaUrl(showData.thumbnail),
+      roadview: resolveMediaUrl(showData.roadview),
     };
 
     setOriginData(safeData);
@@ -493,7 +489,7 @@ const ShowEditPage = () => {
         left="back"
         right="save"
         onSave={handleSave}
-        saveDisabled={!isFormValid}
+        saveDisabled={!isFormValid || isThumbnailCompressing || isDetailCompressing}
         onBack={handleBack}
       />
 
@@ -502,6 +498,7 @@ const ShowEditPage = () => {
           image={thumbnailImage}
           onChange={onThumbnailChange}
           onRemove={() => handleClickRemove(clearThumbnailImage)}
+          isLoading={isThumbnailCompressing}
         />
 
         <div className="flex w-full flex-col items-center gap-6 px-5 pt-5 pb-6">
@@ -648,6 +645,7 @@ const ShowEditPage = () => {
                     image={detailImage}
                     onChange={onDetailChange}
                     onRemove={() => handleClickRemove(clearDetailImage)}
+                    isLoading={isDetailCompressing}
                   />
                 </div>
 

--- a/src/pages/admin/ShowEditPage.jsx
+++ b/src/pages/admin/ShowEditPage.jsx
@@ -28,6 +28,7 @@ import Timepicker from '@/components/Timepicker';
 import Button from '@/components/Button';
 import { FESTIVAL_TIME } from '@/constants/time';
 import { resolveMediaUrl } from '@/utils/mediaUrl';
+import { isSnsUrl } from '@/utils/snsHelper';
 
 const ERROR_TEXT_CLASS = 'text-xs font-normal leading-4 font-normal tracking-0';
 const ERROR_TEXT_STYLE = {
@@ -347,6 +348,8 @@ const ShowEditPage = () => {
       name: '',
       category: '',
       schedule: '',
+      snsInstagram: '',
+      snsKakao: '',
       notices: [],
       setlists: [],
     };
@@ -354,6 +357,11 @@ const ShowEditPage = () => {
     if (!form.name.trim()) newErrors.name = '부스명을 입력해주세요.';
     if (!category) newErrors.category = '카테고리를 선택해주세요.';
     if (!selectedDay) newErrors.schedule = '운영 시간을 선택해주세요.';
+
+    if (form.snsInstagram.trim() && !isSnsUrl(form.snsInstagram))
+      newErrors.snsInstagram = '인스타그램 또는 카카오 URL을 입력해주세요.';
+    if (form.snsKakao.trim() && !isSnsUrl(form.snsKakao))
+      newErrors.snsKakao = '인스타그램 또는 카카오 URL을 입력해주세요.';
 
     newErrors.notices = notices.map((n) => ({
       title: !n.title.trim() ? '제목을 입력해주세요.' : '',
@@ -368,6 +376,8 @@ const ShowEditPage = () => {
       !newErrors.name &&
       !newErrors.category &&
       !newErrors.schedule &&
+      !newErrors.snsInstagram &&
+      !newErrors.snsKakao &&
       newErrors.notices.every((n) => !n.title && !n.content) &&
       newErrors.setlists.every((s) => !s.name);
 
@@ -474,7 +484,7 @@ const ShowEditPage = () => {
     }
 
     // 8. sns
-    const currentSns = [form.snsKakao, form.snsInstagram].filter((v) => v && v.trim() !== '');
+    const currentSns = [form.snsInstagram, form.snsKakao].filter((v) => v && v.trim() !== '');
 
     formData.append('sns', JSON.stringify(currentSns));
 
@@ -675,8 +685,14 @@ const ShowEditPage = () => {
                       value={form.snsInstagram}
                       onChange={(value) => handleChange('snsInstagram', value)}
                       placeholder="https://www.instagram.com/"
+                      error={!!errors.snsInstagram}
                     />
                   </div>
+                  {errors.snsInstagram && (
+                    <p className={`${ERROR_TEXT_CLASS} -mt-1.5 pl-9.5`} style={ERROR_TEXT_STYLE}>
+                      {errors.snsInstagram}
+                    </p>
+                  )}
                   <div className="flex items-center gap-3 self-stretch">
                     <img src="/icons/logo-kakaotalkcolor.svg" className="rounded-md" />
                     <Input
@@ -684,8 +700,14 @@ const ShowEditPage = () => {
                       value={form.snsKakao}
                       onChange={(value) => handleChange('snsKakao', value)}
                       placeholder="http://pf.kakao.com/"
+                      error={!!errors.snsKakao}
                     />
                   </div>
+                  {errors.snsKakao && (
+                    <p className={`${ERROR_TEXT_CLASS} -mt-1.5 pl-9.5`} style={ERROR_TEXT_STYLE}>
+                      {errors.snsKakao}
+                    </p>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -14,6 +14,7 @@ import { useMyProfile, useScrollToTop } from '@/hooks';
 import Header from '@/components/Header';
 import Button from '@/components/Button';
 import ImageCard from '@/components/Card/ImageCard';
+import { resolveMediaUrl } from '@/utils/mediaUrl';
 
 const MyPage = () => {
   const navigate = useNavigate();
@@ -165,7 +166,7 @@ const MyPage = () => {
                 <ImageCard
                   key={scrap.id}
                   name={scrap.name}
-                  image={scrap.thumbnail}
+                  image={resolveMediaUrl(scrap.thumbnail)}
                   onClick={() => goScrapDetail(scrap.target_id)}
                 />
               ))}

--- a/src/utils/errorHelper.js
+++ b/src/utils/errorHelper.js
@@ -1,0 +1,17 @@
+/**
+ * 에러 응답에서 사용자에게 보여줄 메시지를 추출한다.
+ * api 인터셉터가 에러를 응답 본문(object)으로 reject 하므로 그 형태를 처리한다.
+ */
+export const getErrorMessage = (err) => {
+  if (!err) return null;
+  if (typeof err === 'string') return err;
+  if (typeof err.detail === 'string') return err.detail;
+  if (typeof err.message === 'string') return err.message;
+
+  // DRF 필드 에러: { field: ["메시지", ...] } → 첫 메시지
+  const firstValue = Object.values(err)[0];
+  if (Array.isArray(firstValue) && typeof firstValue[0] === 'string') return firstValue[0];
+  if (typeof firstValue === 'string') return firstValue;
+
+  return null;
+};

--- a/src/utils/mediaUrl.js
+++ b/src/utils/mediaUrl.js
@@ -1,0 +1,18 @@
+/**
+ * 서버 미디어 URL 보정 유틸
+ */
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+/**
+ * 서버가 주는 미디어 URL을 화면에서 바로 쓸 수 있게 보정한다.
+ * - /media/... 상대 경로 → API 서버 주소를 prefix
+ * - http:// 절대 경로 → https 로 교정
+ * - 그 외(https 절대 경로, /images 등 로컬 자산, 빈 값) → 그대로
+ */
+export const resolveMediaUrl = (url) => {
+  if (!url) return url;
+  if (url.startsWith('/media/')) return `${API_BASE_URL}${url}`;
+  if (url.startsWith('http://')) return url.replace(/^http:\/\//, 'https://');
+  return url;
+};

--- a/src/utils/snsHelper.js
+++ b/src/utils/snsHelper.js
@@ -2,24 +2,38 @@
  * SNS URL 매핑 유틸리티
  */
 
+const SNS_PLATFORMS = [
+  { type: 'instagram', keyword: 'insta', icon: '/icons/logo-instagramcolor.svg' },
+  { type: 'kakaotalk', keyword: 'kakao', icon: '/icons/logo-kakaotalkcolor.svg' },
+];
+
 /**
- * SNS URL 배열을 플랫폼별로 매핑
- * URL에 특정 키워드가 포함되어 있으면 해당 SNS로 매핑하고,
- * 매칭되지 않으면 null 반환
+ * SNS URL 배열을 URL 내용 기반으로 플랫폼 매핑한다.
+ * 같은 플랫폼이 여러 개여도 모두 포함하며, 매칭되지 않는 URL은 제외한다.
  *
  * @param {string[]} snsUrls - SNS URL 배열
- * @returns {{ instagram: string | null, kakaotalk: string | null }}
+ * @returns {{ type: string, icon: string, url: string }[]}
  */
 export const mapSnsUrls = (snsUrls) => {
-  if (!snsUrls || !Array.isArray(snsUrls)) {
-    return {
-      instagram: null,
-      kakaotalk: null,
-    };
-  }
+  if (!Array.isArray(snsUrls)) return [];
 
-  return {
-    instagram: snsUrls.find((url) => url?.toLowerCase().includes('insta')) || null,
-    kakaotalk: snsUrls.find((url) => url?.toLowerCase().includes('kakao')) || null,
-  };
+  return snsUrls
+    .map((url) => {
+      if (!url?.trim()) return null;
+      const platform = SNS_PLATFORMS.find((p) => url.toLowerCase().includes(p.keyword));
+      return platform ? { type: platform.type, icon: platform.icon, url } : null;
+    })
+    .filter(Boolean);
+};
+
+/**
+ * URL 이 지원하는 SNS 플랫폼(인스타그램/카카오) 중 하나에 해당하는지 검사한다.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export const isSnsUrl = (url) => {
+  if (!url) return false;
+  const lower = url.toLowerCase();
+  return SNS_PLATFORMS.some((p) => lower.includes(p.keyword));
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz"
   integrity sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.24.4", "@babel/core@^7.28.5":
+"@babel/core@^7.24.4", "@babel/core@^7.28.5":
   version "7.28.6"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz"
   integrity sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==
@@ -160,10 +160,157 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@emnapi/core@^1.7.1":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
+  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.1"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.7.1":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.1", "@emnapi/wasi-threads@^1.1.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
+  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
+  dependencies:
+    tslib "^2.4.0"
+
+"@esbuild/aix-ppc64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz#521cbd968dcf362094034947f76fa1b18d2d403c"
+  integrity sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==
+
+"@esbuild/android-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz#61ea550962d8aa12a9b33194394e007657a6df57"
+  integrity sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==
+
+"@esbuild/android-arm@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.2.tgz#554887821e009dd6d853f972fde6c5143f1de142"
+  integrity sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==
+
+"@esbuild/android-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.2.tgz#a7ce9d0721825fc578f9292a76d9e53334480ba2"
+  integrity sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==
+
 "@esbuild/darwin-arm64@0.27.2":
   version "0.27.2"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz"
   integrity sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==
+
+"@esbuild/darwin-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz#e741fa6b1abb0cd0364126ba34ca17fd5e7bf509"
+  integrity sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==
+
+"@esbuild/freebsd-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz#2b64e7116865ca172d4ce034114c21f3c93e397c"
+  integrity sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==
+
+"@esbuild/freebsd-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz#e5252551e66f499e4934efb611812f3820e990bb"
+  integrity sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==
+
+"@esbuild/linux-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz#dc4acf235531cd6984f5d6c3b13dbfb7ddb303cb"
+  integrity sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==
+
+"@esbuild/linux-arm@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz#56a900e39240d7d5d1d273bc053daa295c92e322"
+  integrity sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==
+
+"@esbuild/linux-ia32@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz#d4a36d473360f6870efcd19d52bbfff59a2ed1cc"
+  integrity sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==
+
+"@esbuild/linux-loong64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz#fcf0ab8c3eaaf45891d0195d4961cb18b579716a"
+  integrity sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==
+
+"@esbuild/linux-mips64el@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz#598b67d34048bb7ee1901cb12e2a0a434c381c10"
+  integrity sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==
+
+"@esbuild/linux-ppc64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz#3846c5df6b2016dab9bc95dde26c40f11e43b4c0"
+  integrity sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==
+
+"@esbuild/linux-riscv64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz#173d4475b37c8d2c3e1707e068c174bb3f53d07d"
+  integrity sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==
+
+"@esbuild/linux-s390x@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz#f7a4790105edcab8a5a31df26fbfac1aa3dacfab"
+  integrity sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==
+
+"@esbuild/linux-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz#2ecc1284b1904aeb41e54c9ddc7fcd349b18f650"
+  integrity sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==
+
+"@esbuild/netbsd-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz#e2863c2cd1501845995cb11adf26f7fe4be527b0"
+  integrity sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==
+
+"@esbuild/netbsd-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz#93f7609e2885d1c0b5a1417885fba8d1fcc41272"
+  integrity sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==
+
+"@esbuild/openbsd-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz#a1985604a203cdc325fd47542e106fafd698f02e"
+  integrity sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==
+
+"@esbuild/openbsd-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz#8209e46c42f1ffbe6e4ef77a32e1f47d404ad42a"
+  integrity sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==
+
+"@esbuild/openharmony-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz#8fade4441893d9cc44cbd7dcf3776f508ab6fb2f"
+  integrity sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==
+
+"@esbuild/sunos-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz#980d4b9703a16f0f07016632424fc6d9a789dfc2"
+  integrity sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==
+
+"@esbuild/win32-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz#1c09a3633c949ead3d808ba37276883e71f6111a"
+  integrity sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==
+
+"@esbuild/win32-ia32@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz#1b1e3a63ad4bef82200fef4e369e0fff7009eee5"
+  integrity sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==
+
+"@esbuild/win32-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz#9e585ab6086bef994c6e8a5b3a0481219ada862b"
+  integrity sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==
 
 "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
@@ -215,7 +362,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@^9.39.1", "@eslint/js@9.39.2":
+"@eslint/js@9.39.2", "@eslint/js@^9.39.1":
   version "9.39.2"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz"
   integrity sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==
@@ -290,6 +437,13 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@napi-rs/wasm-runtime@^1.1.0":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz#a46bbfedc29751b7170c5d23bc1d8ee8c7e3c1e1"
+  integrity sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.1"
+
 "@rolldown/pluginutils@1.0.0-beta.53":
   version "1.0.0-beta.53"
   resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz"
@@ -303,10 +457,130 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@rollup/rollup-android-arm-eabi@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.56.0.tgz#067cfcd81f1c1bfd92aefe3ad5ef1523549d5052"
+  integrity sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==
+
+"@rollup/rollup-android-arm64@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.56.0.tgz#85e39a44034d7d4e4fee2a1616f0bddb85a80517"
+  integrity sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==
+
 "@rollup/rollup-darwin-arm64@4.56.0":
   version "4.56.0"
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.56.0.tgz"
   integrity sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==
+
+"@rollup/rollup-darwin-x64@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.56.0.tgz#89ae6c66b1451609bd1f297da9384463f628437d"
+  integrity sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==
+
+"@rollup/rollup-freebsd-arm64@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.56.0.tgz#cdbdb9947b26e76c188a31238c10639347413628"
+  integrity sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==
+
+"@rollup/rollup-freebsd-x64@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.56.0.tgz#9b1458d07b6e040be16ee36d308a2c9520f7f7cc"
+  integrity sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.56.0.tgz#1d50ded7c965d5f125f5832c971ad5b287befef7"
+  integrity sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==
+
+"@rollup/rollup-linux-arm-musleabihf@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.56.0.tgz#53597e319b7e65990d3bc2a5048097384814c179"
+  integrity sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==
+
+"@rollup/rollup-linux-arm64-gnu@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.56.0.tgz#597002909dec198ca4bdccb25f043d32db3d6283"
+  integrity sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==
+
+"@rollup/rollup-linux-arm64-musl@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.56.0.tgz#286f0e0f799545ce288bdc5a7c777261fcba3d54"
+  integrity sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==
+
+"@rollup/rollup-linux-loong64-gnu@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.56.0.tgz#1fab07fa1a4f8d3697735b996517f1bae0ba101b"
+  integrity sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==
+
+"@rollup/rollup-linux-loong64-musl@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.56.0.tgz#efc2cb143d6c067f95205482afb177f78ed9ea3d"
+  integrity sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==
+
+"@rollup/rollup-linux-ppc64-gnu@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.56.0.tgz#e8de8bd3463f96b92b7dfb7f151fd80ffe8a937c"
+  integrity sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==
+
+"@rollup/rollup-linux-ppc64-musl@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.56.0.tgz#8c508fe28a239da83b3a9da75bcf093186e064b4"
+  integrity sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==
+
+"@rollup/rollup-linux-riscv64-gnu@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.56.0.tgz#ff6d51976e0830732880770a9e18553136b8d92b"
+  integrity sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==
+
+"@rollup/rollup-linux-riscv64-musl@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.56.0.tgz#325fb35eefc7e81d75478318f0deee1e4a111493"
+  integrity sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==
+
+"@rollup/rollup-linux-s390x-gnu@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.56.0.tgz#37410fabb5d3ba4ad34abcfbe9ba9b6288413f30"
+  integrity sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==
+
+"@rollup/rollup-linux-x64-gnu@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.56.0.tgz#8ef907a53b2042068fc03fcc6a641e2b02276eca"
+  integrity sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==
+
+"@rollup/rollup-linux-x64-musl@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.56.0.tgz#61b9ba09ea219e0174b3f35a6ad2afc94bdd5662"
+  integrity sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==
+
+"@rollup/rollup-openbsd-x64@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.56.0.tgz#fc4e54133134c1787d0b016ffdd5aeb22a5effd3"
+  integrity sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==
+
+"@rollup/rollup-openharmony-arm64@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.56.0.tgz#959ae225b1eeea0cc5b7c9f88e4834330fb6cd09"
+  integrity sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==
+
+"@rollup/rollup-win32-arm64-msvc@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.56.0.tgz#842acd38869fa1cbdbc240c76c67a86f93444c27"
+  integrity sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==
+
+"@rollup/rollup-win32-ia32-msvc@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.56.0.tgz#7ab654def4042df44cb29f8ed9d5044e850c66d5"
+  integrity sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==
+
+"@rollup/rollup-win32-x64-gnu@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.56.0.tgz#7426cdec1b01d2382ffd5cda83cbdd1c8efb3ca6"
+  integrity sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==
+
+"@rollup/rollup-win32-x64-msvc@4.56.0":
+  version "4.56.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.56.0.tgz#9eec0212732a432c71bde0350bc40b673d15b2db"
+  integrity sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -326,10 +600,72 @@
     source-map-js "^1.2.1"
     tailwindcss "4.1.18"
 
+"@tailwindcss/oxide-android-arm64@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz#79717f87e90135e5d3d23a3d3aecde4ca5595dd5"
+  integrity sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==
+
 "@tailwindcss/oxide-darwin-arm64@4.1.18":
   version "4.1.18"
   resolved "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz"
   integrity sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==
+
+"@tailwindcss/oxide-darwin-x64@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz#c05991c85aa2af47bf9d1f8172fe9e4636591e79"
+  integrity sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==
+
+"@tailwindcss/oxide-freebsd-x64@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz#3d48e8d79fd08ece0e02af8e72d5059646be34d0"
+  integrity sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==
+
+"@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz#982ecd1a65180807ccfde67dc17c6897f2e50aa8"
+  integrity sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==
+
+"@tailwindcss/oxide-linux-arm64-gnu@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz#df49357bc9737b2e9810ea950c1c0647ba6573c3"
+  integrity sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==
+
+"@tailwindcss/oxide-linux-arm64-musl@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz#b266c12822bf87883cf152615f8fffb8519d689c"
+  integrity sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==
+
+"@tailwindcss/oxide-linux-x64-gnu@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz#5c737f13dd9529b25b314e6000ff54e05b3811da"
+  integrity sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==
+
+"@tailwindcss/oxide-linux-x64-musl@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz#3380e17f7be391f1ef924be9f0afe1f304fe3478"
+  integrity sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==
+
+"@tailwindcss/oxide-wasm32-wasi@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz#9464df0e28a499aab1c55e97682be37b3a656c88"
+  integrity sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==
+  dependencies:
+    "@emnapi/core" "^1.7.1"
+    "@emnapi/runtime" "^1.7.1"
+    "@emnapi/wasi-threads" "^1.1.0"
+    "@napi-rs/wasm-runtime" "^1.1.0"
+    "@tybys/wasm-util" "^0.10.1"
+    tslib "^2.4.0"
+
+"@tailwindcss/oxide-win32-arm64-msvc@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz#bbcdd59c628811f6a0a4d5b09616967d8fb0c4d4"
+  integrity sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==
+
+"@tailwindcss/oxide-win32-x64-msvc@4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz#9c628d04623aa4c3536c508289f58d58ba4b3fb1"
+  integrity sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==
 
 "@tailwindcss/oxide@4.1.18":
   version "4.1.18"
@@ -382,12 +718,19 @@
   dependencies:
     "@tanstack/query-devtools" "5.100.1"
 
-"@tanstack/react-query@^5.100.1", "@tanstack/react-query@^5.96.2":
+"@tanstack/react-query@^5.96.2":
   version "5.100.1"
   resolved "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.1.tgz"
   integrity sha512-UgWRLhQKprC37SsO6y1zRabOqDmM2gsdTNPbqTT35yl7kOOhwXU4nyfOiGHXPwoEFJV1IpSk85hjIFjNFWVpzw==
   dependencies:
     "@tanstack/query-core" "5.100.1"
+
+"@tybys/wasm-util@^0.10.1":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
+  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -430,7 +773,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^1.0.6", "@types/estree@1.0.8":
+"@types/estree@*", "@types/estree@1.0.8", "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -450,7 +793,7 @@
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react@^19.2.0", "@types/react@^19.2.5", "@types/react@>=18.0.0":
+"@types/react@^19.2.5":
   version "19.2.9"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz"
   integrity sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==
@@ -474,12 +817,12 @@
     "@typescript-eslint/types" "8.58.0"
     "@typescript-eslint/visitor-keys" "8.58.0"
 
-"@typescript-eslint/tsconfig-utils@^8.58.0", "@typescript-eslint/tsconfig-utils@8.58.0":
+"@typescript-eslint/tsconfig-utils@8.58.0", "@typescript-eslint/tsconfig-utils@^8.58.0":
   version "8.58.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz"
   integrity sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==
 
-"@typescript-eslint/types@^8.58.0", "@typescript-eslint/types@8.58.0":
+"@typescript-eslint/types@8.58.0", "@typescript-eslint/types@^8.58.0":
   version "8.58.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz"
   integrity sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==
@@ -534,7 +877,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0:
+acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -719,7 +1062,14 @@ brace-expansion@^5.0.5:
   dependencies:
     balanced-match "^4.0.2"
 
-browserslist@^4.24.0, browserslist@^4.28.1, "browserslist@>= 4.21.0":
+browser-image-compression@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/browser-image-compression/-/browser-image-compression-2.0.2.tgz#4d5ef8882e9e471d6d923715ceb9034499d14eaa"
+  integrity sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==
+  dependencies:
+    uzip "0.20201231.0"
+
+browserslist@^4.24.0, browserslist@^4.28.1:
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -1201,7 +1551,7 @@ eslint-visitor-keys@^5.0.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz"
   integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
-"eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", "eslint@^8.57.0 || ^9.0.0 || ^10.0.0", eslint@^9.39.2, eslint@>=7, eslint@>=7.0.0, eslint@>=8.40:
+eslint@^9.39.2:
   version "9.39.2"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz"
   integrity sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==
@@ -1742,7 +2092,7 @@ iterator.prototype@^1.1.5:
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
 
-jiti@*, jiti@^2.6.1, jiti@>=1.21.0:
+jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
@@ -1816,12 +2166,62 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lightningcss-android-arm64@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz#6966b7024d39c94994008b548b71ab360eb3a307"
+  integrity sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==
+
 lightningcss-darwin-arm64@1.30.2:
   version "1.30.2"
   resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz"
   integrity sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==
 
-lightningcss@^1.21.0, lightningcss@1.30.2:
+lightningcss-darwin-x64@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz#5ce87e9cd7c4f2dcc1b713f5e8ee185c88d9b7cd"
+  integrity sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==
+
+lightningcss-freebsd-x64@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz#6ae1d5e773c97961df5cff57b851807ef33692a5"
+  integrity sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==
+
+lightningcss-linux-arm-gnueabihf@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz#62c489610c0424151a6121fa99d77731536cdaeb"
+  integrity sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==
+
+lightningcss-linux-arm64-gnu@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz#2a3661b56fe95a0cafae90be026fe0590d089298"
+  integrity sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==
+
+lightningcss-linux-arm64-musl@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz#d7ddd6b26959245e026bc1ad9eb6aa983aa90e6b"
+  integrity sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==
+
+lightningcss-linux-x64-gnu@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz#5a89814c8e63213a5965c3d166dff83c36152b1a"
+  integrity sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==
+
+lightningcss-linux-x64-musl@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz#808c2e91ce0bf5d0af0e867c6152e5378c049728"
+  integrity sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==
+
+lightningcss-win32-arm64-msvc@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz#ab4a8a8a2e6a82a4531e8bbb6bf0ff161ee6625a"
+  integrity sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==
+
+lightningcss-win32-x64-msvc@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz#f01f382c8e0a27e1c018b0bee316d210eac43b6e"
+  integrity sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==
+
+lightningcss@1.30.2:
   version "1.30.2"
   resolved "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz"
   integrity sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==
@@ -2062,7 +2462,7 @@ picomatch@^2.2.2:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.3:
+picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -2077,7 +2477,7 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.1.0, postcss@^8.5.6:
+postcss@^8.5.6:
   version "8.5.6"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz"
   integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
@@ -2096,7 +2496,7 @@ prettier-plugin-tailwindcss@^0.7.2:
   resolved "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.2.tgz"
   integrity sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==
 
-prettier@^3.0, prettier@^3.8.1:
+prettier@^3.8.1:
   version "3.8.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz"
   integrity sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==
@@ -2120,7 +2520,7 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-react-dom@*, react-dom@^19.2.0, react-dom@>=18:
+react-dom@^19.2.0:
   version "19.2.3"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz"
   integrity sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==
@@ -2157,7 +2557,7 @@ react-zoom-pan-pinch@^3.7.0:
   resolved "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz"
   integrity sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==
 
-react@*, "react@^18 || ^19", react@^19.2.0, react@^19.2.3, react@>=18, react@>=18.0.0:
+react@^19.2.0:
   version "19.2.3"
   resolved "https://registry.npmjs.org/react/-/react-19.2.3.tgz"
   integrity sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==
@@ -2477,7 +2877,7 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tailwindcss@^4.1.18, tailwindcss@4.1.18:
+tailwindcss@4.1.18, tailwindcss@^4.1.18:
   version "4.1.18"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz"
   integrity sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==
@@ -2509,6 +2909,11 @@ tsconfig-paths@^3.15.0:
     json5 "^1.0.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -2562,11 +2967,6 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript@^5.4.0, typescript@>=4.8.4, "typescript@>=4.8.4 <6.1.0":
-  version "5.9.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
-
 unbox-primitive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz"
@@ -2592,6 +2992,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+uzip@0.20201231.0:
+  version "0.20201231.0"
+  resolved "https://registry.yarnpkg.com/uzip/-/uzip-0.20201231.0.tgz#9e64b065b9a8ebf26eb7583fe8e77e1d9a15ed14"
+  integrity sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==
+
 vite-plugin-eslint@^1.8.1:
   version "1.8.1"
   resolved "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz"
@@ -2601,7 +3006,7 @@ vite-plugin-eslint@^1.8.1:
     "@types/eslint" "^8.4.5"
     rollup "^2.77.2"
 
-"vite@^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", "vite@^5.2.0 || ^6 || ^7", vite@^7.2.4, vite@>=2:
+vite@^7.2.4:
   version "7.3.1"
   resolved "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz"
   integrity sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->

- close #246

<br />

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

### Summary
- 이미지 업로드 시 클라이언트 압축 기능 추가 (썸네일·로드뷰·상품 이미지 전체)
- 서버 미디어 URL 보정 로직을 `resolveMediaUrl` 하나로 통합 (상대경로·http→https)
- 저장 실패 시 서버 에러 메시지를 토스트에 노출
- SNS 아이콘을 위치가 아닌 URL 기반으로 매핑 + SNS URL 형식 검증 추가

### 상세 변경사항

#### 1. 이미지 압축
- `browser-image-compression` 도입, `useImageCompression` 훅 신설 (최대 1MB / 1920px, Web Worker)
  - 압축 결과를 원본 파일명을 가진 실제 `File`로 래핑 (FormData 확장자 보존)
- `useImageUploader`에 압축 통합 + 업로드 전 **10MB 용량 검사**(초과 시 토스트)
- 상품 이미지를 `ProductItem` 컴포넌트로 분리해 항목별 `useImageUploader` 적용
- 압축 중 업로더에 로딩 스피너 오버레이 표시
- 압축 진행 중에는 저장 버튼 비활성화

#### 2. 미디어 URL 보정 통합
- `src/utils/mediaUrl.js`의 `resolveMediaUrl`로 통합 — 흩어져 있던 `fixUrl`/`sanitizeUrl`/`toMediaUrl` 제거
  - `/media/...` 상대경로 → API 서버 주소 prefix, `http://` → `https://`
- 부스/공연 수정·관리·상세 페이지, 마이페이지, 카드 컴포넌트 전체에 적용

#### 3. 에러 토스트
- `src/utils/errorHelper.js`의 `getErrorMessage`로 서버 응답에서 메시지 추출
- 부스/공연 수정 저장 실패 시 서버 에러 메시지를 토스트로 표시

#### 4. SNS
- `mapSnsUrls`를 URL 기반 매핑 리스트로 변경 (같은 플랫폼 여러 개 지원)
- `isSnsUrl` 추가 — SNS 입력값에 `instagram`/`kakao` 미포함 시 에러 메시지 + 저장 버튼 비활성화
<br />

## 📸 UI 작업 시

<!-- 이미지 or 영상 or 프리뷰 링크 첨부 -->
<!-- 프리뷰 링크에 해당 페이지의 라우트 경로까지 포함하여 작성 -->

<br />

## 💬 To. Reviewer (선택)

<br />

## ✅ 체크 리스트

- [ ] main 브랜치 pull 완료
- [ ] Reviewers 설정
- [ ] Assignees 설정
- [ ] Labels 설정
- [ ] Projects 설정
- [ ] Milestone 설정
