### PR TITLE
 바텀시트 스크롤 차단, 스크랩 버튼 상태 동기화 수정

### DIFF
--- a/src/components/BottomsheetDrag.jsx
+++ b/src/components/BottomsheetDrag.jsx
@@ -24,6 +24,8 @@ const BottomsheetDrag = ({ children, scrollContainerRef }) => {
   const startYRef = useRef(0);
   const startHeightRef = useRef(0);
   const dragHeightRef = useRef(null);
+  const internalScrollRef = useRef(null);
+  const containerRef = scrollContainerRef || internalScrollRef;
 
   const handlePointerDown = useCallback(
     (e) => {
@@ -76,12 +78,14 @@ const BottomsheetDrag = ({ children, scrollContainerRef }) => {
   })();
 
   useEffect(() => {
-    const el = scrollContainerRef?.current;
+    const el = containerRef?.current;
     if (!el) return;
 
     let lastTouchY = null;
 
     const handleTouchStart = (e) => {
+      // touchstart 단계부터 막아야 외부(지도 라이브러리)가 팬 추적을 시작하지 않음
+      e.stopPropagation();
       lastTouchY = e.touches[0].clientY;
     };
 
@@ -123,11 +127,19 @@ const BottomsheetDrag = ({ children, scrollContainerRef }) => {
       }
     };
 
+    // Pointer Events도 함께 차단 (react-zoom-pan-pinch가 내부적으로 pointer 사용)
+    const stopPointer = (e) => {
+      e.stopPropagation();
+    };
+
     el.addEventListener('touchstart', handleTouchStart, { passive: true });
     el.addEventListener('touchmove', handleTouchMove, { passive: false });
     el.addEventListener('touchend', handleTouchEnd, { passive: true });
     el.addEventListener('touchcancel', handleTouchEnd, { passive: true });
     el.addEventListener('wheel', handleWheel, { passive: false });
+    el.addEventListener('pointerdown', stopPointer);
+    el.addEventListener('pointermove', stopPointer);
+    el.addEventListener('pointerup', stopPointer);
 
     return () => {
       el.removeEventListener('touchstart', handleTouchStart);
@@ -135,8 +147,11 @@ const BottomsheetDrag = ({ children, scrollContainerRef }) => {
       el.removeEventListener('touchend', handleTouchEnd);
       el.removeEventListener('touchcancel', handleTouchEnd);
       el.removeEventListener('wheel', handleWheel);
+      el.removeEventListener('pointerdown', stopPointer);
+      el.removeEventListener('pointermove', stopPointer);
+      el.removeEventListener('pointerup', stopPointer);
     };
-  }, [scrollContainerRef]);
+  }, [containerRef]);
 
   return (
     <div
@@ -160,7 +175,7 @@ const BottomsheetDrag = ({ children, scrollContainerRef }) => {
 
       {/* 헤더 영역 padding */}
       <div
-        ref={scrollContainerRef}
+        ref={containerRef}
         className={`relative w-full flex-1 overflow-y-auto ${isFull ? 'pt-18' : ''}`}
         style={{ overscrollBehavior: 'contain', touchAction: 'pan-y' }}
       >

--- a/src/components/ScrapButton.jsx
+++ b/src/components/ScrapButton.jsx
@@ -48,6 +48,7 @@ const ScrapButton = ({
 
   const scrapQueryKey = type === 'show' ? ['myScrapShows'] : ['myScrapBooths'];
   const listQueryKey = type === 'show' ? ['shows'] : ['booths'];
+  const detailQueryKey = type === 'show' ? ['show', id] : ['booth', id];
 
   // TanStack Query useMutation으로 스크랩 토글
   const mutation = useMutation({
@@ -84,10 +85,12 @@ const ScrapButton = ({
       return { previousScrapped, previousCount };
     },
 
-    // 성공 시: 서버와 동기화
+    // 성공 시: 서버와 동기화 (모든 관련 캐시 무효화)
     onSuccess: (_data, _variables, context) => {
       queryClient.invalidateQueries({ queryKey: listQueryKey });
       queryClient.invalidateQueries({ queryKey: scrapQueryKey });
+      queryClient.invalidateQueries({ queryKey: detailQueryKey });
+      queryClient.invalidateQueries({ queryKey: ['searchResults'] });
       queryClient.invalidateQueries({ queryKey: ['myProfile'] });
 
       if (onToggle) onToggle(!context.previousScrapped);


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->

- close #263

<br />

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
### 🐛 바텀시트 내부 스크롤이 안 먹히는 문제 수정 (`BottomsheetDrag.jsx`)

- **원인 1**: `BoothDetailSheet`, `ShowDetailSheet`는 `scrollContainerRef`를 넘기지 않아서 스크롤 차단 로직이 아예 작동하지 않았음
  - → 내부 fallback ref(`internalScrollRef`)를 추가해 외부에서 ref를 안 넘겨도 자동으로 작동하도록 수정
- **원인 2**: 기존엔 `touchmove`부터만 stopPropagation 호출 → 그 사이 `touchstart`가 지도 라이브러리(`react-zoom-pan-pinch`)에 도달해 팬(pan) 추적이 이미 시작됨
  - → `handleTouchStart`에도 `e.stopPropagation()` 추가
- **원인 3**: `react-zoom-pan-pinch`는 내부적으로 Pointer Events를 사용하는데, Touch 이벤트만 막고 있어서 Pointer 이벤트는 그대로 지도까지 전파됨
  - → `pointerdown`, `pointermove`, `pointerup` 리스너 추가로 함께 차단

### 🐛 스크랩 버튼 상태가 페이지별로 동기화되지 않는 문제 수정 (`ScrapButton.jsx`)

- **원인**: `mutation.onSuccess`에서 목록(`booths`/`shows`), 스크랩(`myScrapBooths`/`myScrapShows`), 프로필(`myProfile`) 캐시만 무효화하고 있어서, **상세 조회 캐시**(`['booth', id]`/`['show', id]`)와 **검색 결과 캐시**(`['searchResults']`)는 stale 상태로 남아있었음
- 두 캐시 키도 invalidate 대상에 추가하여 모든 페이지에서 스크랩 상태가 동기화되도록 수정


<br />

## 📸 UI 작업 시

<!-- 이미지 or 영상 or 프리뷰 링크 첨부 -->
<!-- 프리뷰 링크에 해당 페이지의 라우트 경로까지 포함하여 작성 -->

<br />

## 💬 To. Reviewer (선택)

- `BottomsheetDrag` 수정으로 List 시트(`BoothListSheet`, `ShowListSheet`, `EtcSheet`)는 기존 동작(스크롤 위치 저장/복원, 무한 스크롤, 드래그 리사이즈) 그대로 작동합니다. Detail 시트들은 이전에 작동하지 않던 스크롤 차단이 새로 적용되었습니다.
- `ScrapButton` 한 곳만 수정해서 6개 페이지(`BoothListSheet`, `ShowListSheet`, `BoothDetailSheet`, `ShowDetailSheet`, `ScrapBooth`, `ScrapShow`)가 모두 동기화됩니다.

<br />

## ✅ 체크 리스트

- [x] main 브랜치 pull 완료
- [x] Reviewers 설정
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정
