### PR TITLE
필터바/정렬 상단 고정

### DIFF
--- a/src/components/BottomsheetDrag.jsx
+++ b/src/components/BottomsheetDrag.jsx
@@ -50,12 +50,14 @@ const BottomsheetDrag = ({ children, scrollContainerRef }) => {
         dragHeightRef.current = null;
         setDragHeight(null);
         setIsDragging(false);
-        document.removeEventListener('pointermove', handlePointerMove);
-        document.removeEventListener('pointerup', handlePointerUp);
+        // capture phase로 등록한 것은 capture phase로 제거해야 함
+        document.removeEventListener('pointermove', handlePointerMove, true);
+        document.removeEventListener('pointerup', handlePointerUp, true);
       };
 
-      document.addEventListener('pointermove', handlePointerMove);
-      document.addEventListener('pointerup', handlePointerUp);
+      // capture phase로 등록 → 스크롤 컨테이너의 stopPropagation보다 먼저 실행되어 드래그 추적이 끊기지 않음
+      document.addEventListener('pointermove', handlePointerMove, true);
+      document.addEventListener('pointerup', handlePointerUp, true);
     },
     [sheetSize, setSheetSize, setIsDragging],
   );

--- a/src/features/EtcSheet.jsx
+++ b/src/features/EtcSheet.jsx
@@ -96,9 +96,16 @@ const EtcSheet = () => {
       </div>
       <BottomsheetDrag scrollContainerRef={scrollContainerRef}>
         {isFull && <Header left="back" center="title" centerTitle="기타시설" isSheet />}
-        <div className="flex flex-col gap-4 px-5 py-5">
-          <FilterBar type="etc" />
-          <p className="text-sm font-normal text-zinc-500">총 {filteredData.length}개</p>
+        <div className="flex flex-col gap-2 px-5 py-5">
+          {/* 상단 고정 영역 (full 모드에서 sticky) */}
+          <div
+            className={`flex flex-col gap-4 ${
+              isFull ? 'sticky top-0 z-10 -mx-5 -mt-5 bg-white px-5 pt-5 pb-2' : ''
+            }`}
+          >
+            <FilterBar type="etc" />
+            <p className="text-sm font-normal text-zinc-500">총 {filteredData.length}개</p>
+          </div>
           <div className="flex flex-col gap-10">
             {Object.entries(grouped).map(([location, items]) => (
               <div key={location} className="flex flex-col gap-2">

--- a/src/features/booth/BoothListSheet.jsx
+++ b/src/features/booth/BoothListSheet.jsx
@@ -82,10 +82,15 @@ const BoothListSheet = () => {
       </div>
       <BottomsheetDrag scrollContainerRef={scrollContainerRef}>
         {isFull && <Header center="search" />}
-        <div className="flex h-full flex-col gap-4 p-5">
-          <Tab tabs={['부스', '공연']} activeIndex={activeTabIndex} onChange={handleTabChange} />
-          <FilterBar type="booth" />
-          <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-full flex-col p-5">
+          {/* 상단 고정 영역 (full 모드에서 sticky) */}
+          <div
+            className={`flex flex-col gap-4 ${
+              isFull ? 'sticky top-0 z-10 -mx-5 -mt-5 bg-white px-5 pt-5' : ''
+            }`}
+          >
+            <Tab tabs={['부스', '공연']} activeIndex={activeTabIndex} onChange={handleTabChange} />
+            <FilterBar type="booth" />
             <div className="flex items-center justify-between text-sm font-normal text-zinc-500">
               총 {totalCount}개
               <div className="flex items-center gap-2">
@@ -99,7 +104,9 @@ const BoothListSheet = () => {
                 <DropDown type="booth" />
               </div>
             </div>
+          </div>
 
+          <div className="flex min-h-0 flex-1 flex-col">
             {/* 로딩 */}
             {isLoading && (
               <div className="flex h-full items-center justify-center">

--- a/src/features/show/ShowListSheet.jsx
+++ b/src/features/show/ShowListSheet.jsx
@@ -82,10 +82,15 @@ const ShowListSheet = () => {
       </div>
       <BottomsheetDrag scrollContainerRef={scrollContainerRef}>
         {isFull && <Header center="search" />}
-        <div className="flex h-full flex-col gap-4 p-5">
-          <Tab tabs={['부스', '공연']} activeIndex={activeTabIndex} onChange={handleTabChange} />
-          <FilterBar type="show" />
-          <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-full flex-col p-5">
+          {/* 상단 고정 영역 (full 모드에서 sticky) */}
+          <div
+            className={`flex flex-col gap-4 ${
+              isFull ? 'sticky top-0 z-10 -mx-5 -mt-5 bg-white px-5 pt-5' : ''
+            }`}
+          >
+            <Tab tabs={['부스', '공연']} activeIndex={activeTabIndex} onChange={handleTabChange} />
+            <FilterBar type="show" />
             <div className="flex items-center justify-between text-sm font-normal text-zinc-500">
               총 {totalCount}개
               <div className="flex items-center gap-2">
@@ -99,7 +104,9 @@ const ShowListSheet = () => {
                 <DropDown type="show" />
               </div>
             </div>
+          </div>
 
+          <div className="flex min-h-0 flex-1 flex-col">
             {/* 로딩 */}
             {isLoading && (
               <div className="flex h-full items-center justify-center">

--- a/src/pages/my/ScrapBooth.jsx
+++ b/src/pages/my/ScrapBooth.jsx
@@ -10,19 +10,15 @@ import useFilterStore from '@/store/useFilterStore';
 import useLoadingStore from '@/store/useLoadingStore';
 import { useMyScrapBooths } from '@/hooks';
 
-import FilterBar from '@/components/FilterBar';
-import Checkbox from '@/components/Checkbox';
-import DropDown from '@/components/DropDown';
 import BoothCard from '@/components/Card/BoothCard';
 
 const ScrapBooth = () => {
   const navigate = useNavigate();
 
   const scrapBoothFilters = useFilterStore((s) => s.filters.scrap_booth);
-  const setFilter = useFilterStore((s) => s.setFilter);
   const setSheetSize = useBottomsheetStore((s) => s.setSheetSize);
 
-  const { booths, totalCount, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { booths, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useMyScrapBooths(scrapBoothFilters);
 
   const { showLoading, hideLoading } = useLoadingStore();
@@ -31,10 +27,6 @@ const ScrapBooth = () => {
     else hideLoading();
     return () => hideLoading();
   }, [isLoading]);
-
-  const handleBoothExcludeEndedChange = (value) => {
-    setFilter('scrap_booth', 'excludeEnded', value);
-  };
 
   const goBoothDetail = (scrapId) => {
     setSheetSize('full');
@@ -63,21 +55,6 @@ const ScrapBooth = () => {
   return (
     <>
       <div className="flex flex-col gap-4">
-        <FilterBar type="scrap_booth" />
-        <div className="flex items-center justify-between text-sm font-normal text-zinc-500">
-          총 {totalCount}개
-          <div className="flex items-center gap-2">
-            <div className="flex items-center gap-1">
-              종료 제외
-              <Checkbox
-                isSelected={scrapBoothFilters.excludeEnded}
-                onChange={handleBoothExcludeEndedChange}
-              />
-            </div>
-            <DropDown type="scrap_booth" />
-          </div>
-        </div>
-
         {/* 에러 */}
         {isError && (
           <div className="py-24 text-center text-zinc-300">데이터를 불러오는데 실패했습니다.</div>

--- a/src/pages/my/ScrapPage.jsx
+++ b/src/pages/my/ScrapPage.jsx
@@ -5,19 +5,31 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useAuthStore from '@/store/useAuthStore';
+import useFilterStore from '@/store/useFilterStore';
+import { useMyScrapBooths, useMyScrapShows } from '@/hooks';
 
 import Header from '@/components/Header';
 import Tab from '@/components/Tab';
+import FilterBar from '@/components/FilterBar';
+import Checkbox from '@/components/Checkbox';
+import DropDown from '@/components/DropDown';
 import ScrapBooth from '@/pages/my/ScrapBooth';
 import ScrapShow from '@/pages/my/ScrapShow';
-
-const totalCount = 0;
 
 const ScrapPage = () => {
   const [activeIndex, setActiveIndex] = useState(0);
   const navigate = useNavigate();
   const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
   const openLoginSheet = useAuthStore((s) => s.openLoginSheet);
+
+  // 필터 상태 (Zustand 전역)
+  const scrapBoothFilters = useFilterStore((s) => s.filters.scrap_booth);
+  const scrapShowFilters = useFilterStore((s) => s.filters.scrap_show);
+  const setFilter = useFilterStore((s) => s.setFilter);
+
+  // 총 개수 (자식 컴포넌트와 TanStack Query 캐시 공유 → 추가 요청 없음)
+  const { totalCount: boothCount } = useMyScrapBooths(scrapBoothFilters);
+  const { totalCount: showCount } = useMyScrapShows(scrapShowFilters);
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -26,12 +38,36 @@ const ScrapPage = () => {
     }
   }, [isLoggedIn]);
 
+  const isBooth = activeIndex === 0;
+  const filterType = isBooth ? 'scrap_booth' : 'scrap_show';
+  const totalCount = isBooth ? boothCount : showCount;
+  const excludeEnded = isBooth ? scrapBoothFilters.excludeEnded : scrapShowFilters.excludeEnded;
+
+  const handleExcludeEndedChange = (value) => {
+    setFilter(filterType, 'excludeEnded', value);
+  };
+
   return (
     <>
       <Header left="back" center="title" centerTitle="스크랩북" />
-      <div className="mt-18 flex flex-col gap-4 px-5 pt-5">
-        <Tab tabs={['부스', '공연']} activeIndex={activeIndex} onChange={setActiveIndex} />
-        {activeIndex === 0 ? <ScrapBooth /> : <ScrapShow />}
+      <div className="mt-18 flex flex-col px-5">
+        {/* 상단 고정 영역: Tab + FilterBar + 정렬 */}
+        <div className="sticky top-18 z-10 -mx-5 flex flex-col gap-4 bg-white px-5 pt-5">
+          <Tab tabs={['부스', '공연']} activeIndex={activeIndex} onChange={setActiveIndex} />
+          <FilterBar type={filterType} />
+          <div className="flex items-center justify-between text-sm font-normal text-zinc-500">
+            총 {totalCount}개
+            <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1">
+                종료 제외
+                <Checkbox isSelected={excludeEnded} onChange={handleExcludeEndedChange} />
+              </div>
+              <DropDown type={filterType} />
+            </div>
+          </div>
+        </div>
+
+        {isBooth ? <ScrapBooth /> : <ScrapShow />}
       </div>
     </>
   );

--- a/src/pages/my/ScrapShow.jsx
+++ b/src/pages/my/ScrapShow.jsx
@@ -10,19 +10,15 @@ import useFilterStore from '@/store/useFilterStore';
 import useLoadingStore from '@/store/useLoadingStore';
 import { useMyScrapShows } from '@/hooks';
 
-import FilterBar from '@/components/FilterBar';
-import Checkbox from '@/components/Checkbox';
-import DropDown from '@/components/DropDown';
 import ShowCard from '@/components/Card/ShowCard';
 
 const ScrapShow = () => {
   const navigate = useNavigate();
 
   const scrapShowFilters = useFilterStore((s) => s.filters.scrap_show);
-  const setFilter = useFilterStore((s) => s.setFilter);
   const setSheetSize = useBottomsheetStore((s) => s.setSheetSize);
 
-  const { shows, totalCount, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { shows, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useMyScrapShows(scrapShowFilters);
 
   const { showLoading, hideLoading } = useLoadingStore();
@@ -31,10 +27,6 @@ const ScrapShow = () => {
     else hideLoading();
     return () => hideLoading();
   }, [isLoading]);
-
-  const handleShowExcludeEndedChange = (value) => {
-    setFilter('scrap_show', 'excludeEnded', value);
-  };
 
   const goShowDetail = (scrapId) => {
     setSheetSize('full');
@@ -61,21 +53,6 @@ const ScrapShow = () => {
   return (
     <>
       <div className="flex flex-col gap-4">
-        <FilterBar type="scrap_show" />
-        <div className="flex items-center justify-between text-sm font-normal text-zinc-500">
-          총 {totalCount}개
-          <div className="flex items-center gap-2">
-            <div className="flex items-center gap-1">
-              종료 제외
-              <Checkbox
-                isSelected={scrapShowFilters.excludeEnded}
-                onChange={handleShowExcludeEndedChange}
-              />
-            </div>
-            <DropDown type="scrap_show" />
-          </div>
-        </div>
-
         {/* 에러 */}
         {isError && (
           <div className="py-24 text-center text-zinc-300">데이터를 불러오는데 실패했습니다.</div>


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->

- close #267

<br />

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
### ✨ 바텀시트 full 모드에서 상단 영역 sticky 고정

#### `BoothListSheet`, `ShowListSheet`
- Tab + FilterBar + "총 N개 + 종료제외 + DropDown" 영역을 sticky 그룹으로 묶음
- full 모드일 때 시트 상단에 고정되어 부스/공연 카드만 스크롤되도록 구현
- 외부 wrapper를 `h-full` → `min-h-full`로 변경하여 카드가 많아져도 sticky가 전체 스크롤 범위에서 유지되도록 처리

#### `EtcSheet`
- FilterBar + 총개수 영역을 동일한 패턴으로 sticky 처리

### ♻️ 스크랩 페이지 구조 개선 및 상단 영역 고정 (`ScrapPage`, `ScrapBooth`, `ScrapShow`)
- 분리된 sticky 요소들이 stacking 되며 발생하던 시각 버그 해결을 위해 구조 변경
- Tab + FilterBar + "총 N개 + 종료제외 + DropDown" 영역을 모두 `ScrapPage`의 단일 sticky 컨테이너로 통합
- `ScrapBooth`, `ScrapShow`는 카드 목록 렌더링만 담당하도록 단순화
- 페이지 진입 시 항상 상단 고정되어 카드만 스크롤됨
- `ScrapPage`에서 `useMyScrapBooths`/`useMyScrapShows`를 호출해 totalCount를 가져오고, TanStack Query 캐시 공유로 자식 컴포넌트에서 중복 요청 발생하지 않음

### 🐛 바텀시트 드래그 추적 오류 수정 (`BottomsheetDrag`)
- 이전 PR(#264)에서 스크롤 차단을 위해 추가한 pointer event `stopPropagation`이 드래그 핸들의 드래그 추적을 막던 문제 수정
- `document`에 등록하는 `pointermove`/`pointerup` 리스너를 **capture phase**로 등록하여, 스크롤 컨테이너의 `stopPropagation`보다 먼저 실행되도록 변경
- full 모드에서 드래그 핸들로 시트를 부드럽게 내릴 수 있음

<br />

## 📸 UI 작업 시

<!-- 이미지 or 영상 or 프리뷰 링크 첨부 -->
<!-- 프리뷰 링크에 해당 페이지의 라우트 경로까지 포함하여 작성 -->

<br />

## 💬 To. Reviewer (선택)

<br />

## ✅ 체크 리스트

- [x] main 브랜치 pull 완료
- [x] Reviewers 설정
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정
